### PR TITLE
docs(doctest): Test documentation with markdown-doctest

### DIFF
--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -1,0 +1,25 @@
+var xstream = require('.').default;
+
+function noop () {}
+
+module.exports = {
+  require: {
+    xstream: xstream
+  },
+
+  globals: {
+    xs: xstream,
+    stream: xstream.empty(),
+    setInterval: noop,
+    console: {
+      log: noop,
+      error: noop
+    },
+    listener: {
+      next: noop,
+      error: noop,
+      complete: noop
+    }
+  }
+}
+

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ var listener = {
   error: (err) => {
     console.error('The Stream gave me an error: ', err);
   },
-  completed: () => {
+  complete: () => {
     console.log('The Stream told me it is done.');
   },
 }
@@ -162,7 +162,7 @@ Events from a Stream must come from somewhere, right? That's why we need Produce
 Because Streams are Listeners, if you give a Stream as the Listener in `start(stream)`, essentially the Producer is now generating events that will be broadcast on the Stream. Nice, huh? Now a bunch of listeners can be attached to the Stream and they can all get those events originally coming from the Producer. That's why `xs.create(producer)` receives a Producer to be the heart of a new Stream. Check this out:
 
 ```js
-var intervalProducer = {
+var producer = {
   start: function (listener) {
     this.id = setInterval(() => listener.next('yo'), 1000)
   },
@@ -204,6 +204,7 @@ What matters for stopping the Producer is `stream.removeListener`. When the last
 
 The reason the Producer is not suddenly (synchronously) stopped, is that it is often necessary to swap the single listener of a Stream, but still keep its ongoing execution. For instance:
 
+<!-- skip-example -->
 ```js
 var listenerA = {/* ... */}
 var listenerB = {/* ... */}

--- a/markdown/overview.md
+++ b/markdown/overview.md
@@ -1,5 +1,7 @@
 # Overview
 
+<!-- share-code-between-examples -->
+
 XStream has four fundamental types: Stream, Listener, Producer, and MemoryStream.
 
 ## Stream
@@ -29,7 +31,7 @@ var listener = {
   error: (err) => {
     console.error('The Stream gave me an error: ', err);
   },
-  completed: () => {
+  complete: () => {
     console.log('The Stream told me it is done.');
   },
 }
@@ -56,7 +58,7 @@ Events from a Stream must come from somewhere, right? That's why we need Produce
 Because Streams are Listeners, if you give a Stream as the Listener in `start(stream)`, essentially the Producer is now generating events that will be broadcast on the Stream. Nice, huh? Now a bunch of listeners can be attached to the Stream and they can all get those events originally coming from the Producer. That's why `xs.create(producer)` receives a Producer to be the heart of a new Stream. Check this out:
 
 ```js
-var intervalProducer = {
+var producer = {
   start: function (listener) {
     this.id = setInterval(() => listener.next('yo'), 1000)
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "premocha": "npm run lib",
     "mocha": "mocha tests/*.ts tests/**/*.ts --require ts-node/register",
     "postmocha": "rm -rf tests/**/*.js",
-    "test": "npm run lint && npm run mocha",
+    "test": "npm run lint && npm run mocha && npm run doctest",
     "prelib": "rm -rf lib/ && mkdirp lib/ && typings install",
     "lib": "tsc",
     "page-content": "npm run lib && node tools/make-toc.js && node tools/make-factories.js && node tools/make-methods.js && cat markdown/header.md markdown/generated-toc.md markdown/overview.md markdown/generated-factories.md markdown/generated-methods.md markdown/footer.md > .ignore/content.md",
@@ -20,7 +20,8 @@
     "postdist": "uglifyjs dist/xstream.js -o dist/xstream.min.js",
     "start": "npm install && npm prune",
     "prepublish": "npm run lib",
-    "preversion": "npm run dist"
+    "preversion": "npm run dist",
+    "doctest": "markdown-doctest"
   },
   "repository": {
     "type": "git",
@@ -32,8 +33,7 @@
     "url": "https://github.com/staltz/xstream/issues"
   },
   "homepage": "https://github.com/staltz/xstream#readme",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "assert": "^1.3.0",
     "browserify": "^13.0.0",
@@ -42,6 +42,7 @@
     "cz-conventional-changelog": "^1.1.5",
     "es6-promise": "^3.1.2",
     "ghooks": "^1.0.3",
+    "markdown-doctest": "^0.3.3",
     "markdox": "^0.1.10",
     "mkdirp": "^0.5.1",
     "mocha": "^2.4.5",


### PR DESCRIPTION
Fixes several typos/small issues in the documentation as well.

markdown-doctest will now run after mocha as part of npm test. We should also probably get travis set up so that we quickly notice when things break.