### PR TITLE
feat(addListener): throw an error if next, error or complete functions are missing

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1037,6 +1037,18 @@ export class Stream<T> implements InternalListener<T> {
    * @param {Listener<T>} listener
    */
   addListener(listener: Listener<T>): void {
+    if (typeof listener.next !== 'function') {
+      throw new Error('addListener requires a next function.');
+    }
+
+    if (typeof listener.error !== 'function') {
+      throw new Error('addListener requires an error function.');
+    }
+
+    if (typeof listener.complete !== 'function') {
+      throw new Error('addListener requires a complete function.');
+    }
+
     (<InternalListener<T>> (<any> listener))._n = listener.next;
     (<InternalListener<T>> (<any> listener))._e = listener.error;
     (<InternalListener<T>> (<any> listener))._c = listener.complete;

--- a/tests/extra/fromEvent.ts
+++ b/tests/extra/fromEvent.ts
@@ -68,7 +68,7 @@ describe('fromEvent (extra)', () => {
       next(x: any) {
         assert.strictEqual(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.strictEqual(expected.length, 0);
         done();
@@ -89,7 +89,7 @@ describe('fromEvent (extra)', () => {
 
     stream.take(1).addListener({
       next(x) {},
-      error: done.fail,
+      error: done,
       complete() {
         setTimeout(() => {
           assert.strictEqual('test', target.removedEvent);

--- a/tests/factory/combine.ts
+++ b/tests/factory/combine.ts
@@ -11,7 +11,7 @@ describe('xs.combine', () => {
       next: (x) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         done();
@@ -28,7 +28,7 @@ describe('xs.combine', () => {
       next: (x) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         done();

--- a/tests/factory/merge.ts
+++ b/tests/factory/merge.ts
@@ -12,7 +12,7 @@ describe('xs.merge', () => {
       next: (x) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         done();
@@ -29,7 +29,7 @@ describe('xs.merge', () => {
       next: (x) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         done();

--- a/tests/factory/of.ts
+++ b/tests/factory/of.ts
@@ -10,7 +10,7 @@ describe('xs.of', () => {
       next: (x: string) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         done();

--- a/tests/operator/combine.ts
+++ b/tests/operator/combine.ts
@@ -11,7 +11,7 @@ describe('Stream.prototype.combine', () => {
       next: (x) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         done();
@@ -28,7 +28,7 @@ describe('Stream.prototype.combine', () => {
       next: (x) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         done();

--- a/tests/operator/debug.ts
+++ b/tests/operator/debug.ts
@@ -15,8 +15,8 @@ describe('Stream.prototype.debug', () => {
           done();
         }
       },
-      error: done.fail,
-      complete: done.fail,
+      error: done,
+      complete: () => done('complete should not be called'),
     };
     stream.addListener(listener);
   });

--- a/tests/operator/drop.ts
+++ b/tests/operator/drop.ts
@@ -13,8 +13,8 @@ describe('Stream.prototype.drop', () => {
           done();
         }
       },
-      error: done.fail,
-      complete: done.fail,
+      error: done,
+      complete: () => done('complete should not be called'),
     };
     stream.addListener(listener);
   });

--- a/tests/operator/filter.ts
+++ b/tests/operator/filter.ts
@@ -13,8 +13,8 @@ describe('Stream.prototype.filter', () => {
           done();
         }
       },
-      error: done.fail,
-      complete: done.fail,
+      error: done,
+      complete: () => done('complete should not be called'),
     };
     stream.addListener(listener);
   });

--- a/tests/operator/fold.ts
+++ b/tests/operator/fold.ts
@@ -9,7 +9,7 @@ describe('Stream.prototype.fold', () => {
       next: (x: number) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         stream.removeListener(listener);

--- a/tests/operator/last.ts
+++ b/tests/operator/last.ts
@@ -9,7 +9,7 @@ describe('Stream.prototype.last', () => {
       next: (x: number) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         stream.removeListener(listener);

--- a/tests/operator/mapTo.ts
+++ b/tests/operator/mapTo.ts
@@ -13,8 +13,8 @@ describe('Stream.prototype.mapTo', () => {
           done();
         }
       },
-      error: done.fail,
-      complete: done.fail,
+      error: done,
+      complete: () => done('complete should not be called'),
     };
     stream.addListener(listener);
   });

--- a/tests/operator/merge.ts
+++ b/tests/operator/merge.ts
@@ -10,7 +10,7 @@ describe('Stream.prototype.merge', () => {
       next: (x) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         done();
@@ -27,7 +27,7 @@ describe('Stream.prototype.merge', () => {
       next: (x) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         done();

--- a/tests/operator/remember.ts
+++ b/tests/operator/remember.ts
@@ -14,7 +14,7 @@ describe('Stream.prototype.remember', () => {
         next(x) {
           assert.strictEqual(x, expected.shift());
         },
-        error: done.fail,
+        error: done,
         complete: () => {
           assert.strictEqual(expected.length, 0);
           done();

--- a/tests/operator/startWith.ts
+++ b/tests/operator/startWith.ts
@@ -9,7 +9,7 @@ describe('Stream.prototype.startWith', () => {
       next(x: any) {
         assert.strictEqual(x, 1);
       },
-      error: done.fail,
+      error: done,
       complete: done
     });
   });

--- a/tests/operator/take.ts
+++ b/tests/operator/take.ts
@@ -9,7 +9,7 @@ describe('Stream.prototype.take', () => {
       next: (x: number) => {
         assert.equal(x, expected.shift());
       },
-      error: done.fail,
+      error: done,
       complete: () => {
         assert.equal(expected.length, 0);
         stream.removeListener(listener);

--- a/tests/stream.ts
+++ b/tests/stream.ts
@@ -315,4 +315,61 @@ describe('Stream', () => {
     assert.equal(expected2.length, 0);
     done();
   });
+
+  describe('addListener', () => {
+    it('throws a helpful error if you forget the next function', (done) => {
+      const stream = xs.empty();
+      const listener = <Listener<Number>> <any> {};
+
+      try {
+        stream.addListener(listener);
+      } catch (e) {
+        assert.equal(e.message, 'addListener requires a next function.')
+        done();
+      }
+    });
+
+    it('throws a helpful error if you forget the error function', (done) => {
+      const stream = xs.empty();
+      const listener = <Listener<Number>> <any> {
+        next: (x: any) => {}
+      };
+
+      try {
+        stream.addListener(listener);
+      } catch (e) {
+        assert.equal(e.message, 'addListener requires an error function.')
+        done();
+      }
+    });
+
+    it('throws a helpful error if you forget the complete function', (done) => {
+      const stream = xs.empty();
+      const listener = <Listener<Number>> <any> {
+        next: (x: any) => {},
+        error: (err: any) => {}
+      };
+
+      try {
+        stream.addListener(listener);
+      } catch (e) {
+        assert.equal(e.message, 'addListener requires a complete function.')
+        done();
+      }
+    });
+
+    it('throws a helpful error if you pass a non function value as the next function', (done) => {
+      const stream = xs.empty();
+      const listener = <Listener<Number>> <any> {
+        next: undefined
+      };
+
+      try {
+        stream.addListener(listener);
+      } catch (e) {
+        assert.equal(e.message, 'addListener requires a next function.')
+        done();
+      }
+    });
+  });
 });


### PR DESCRIPTION
This class of error is a compiler error in TypeScript, but is a runtime error in JS. Currently we get an error like "this._n is not a function" which is quite cryptic to an end user.

I would add a test for this, but since it's a compiler error in TS I can't see any way to do so.