### PR TITLE
feat(create): Throw an error if an producer is passed without start and stop

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1107,6 +1107,10 @@ export class Stream<T> implements InternalListener<T> {
    */
   static create<T>(producer?: Producer<T>): Stream<T> {
     if (producer) {
+      if (typeof producer.start !== 'function'
+      || typeof producer.stop !== 'function') {
+        throw new Error('producer requires both start and stop functions');
+      }
       internalizeProducer(producer); // mutates the input
     }
     return new Stream(<InternalProducer<T>> (<any> producer));

--- a/tests/stream.ts
+++ b/tests/stream.ts
@@ -316,6 +316,22 @@ describe('Stream', () => {
     done();
   });
 
+  describe('create', () => {
+    it('throws a helpful error if you pass an incomplete producer', (done) => {
+      try {
+        const incompleteProducer = <Producer<any>> <any> {
+          start: () => {},
+          stop: undefined
+        };
+
+        xs.create(incompleteProducer);
+      } catch (e) {
+        assert.equal(e.message, 'producer requires both start and stop functions');
+        done();
+      }
+    });
+  });
+
   describe('addListener', () => {
     it('throws a helpful error if you forget the next function', (done) => {
       const stream = xs.empty();


### PR DESCRIPTION
As discussed in #11.

Is this what you were thinking @staltz?