### PR TITLE
feat(core): Only have 1 Type Stream [WIP]

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import {Stream, MemoryStream, MimicStream, Listener, Producer, Operator} from './core';
-export {Stream, MemoryStream, MimicStream, Listener, Producer, Operator};
+import {Stream, MimicStream, Listener, Producer, Operator} from './core';
+export {Stream, MimicStream, Listener, Producer, Operator};
 export default Stream;

--- a/tests/memoryStream.ts
+++ b/tests/memoryStream.ts
@@ -131,4 +131,36 @@ describe('MemoryStream', () => {
       },
     });
   });
+
+  it('should continue to be a stream with memory when operators are used', (done) => {
+    const stream = xs.periodic(100).remember().take(3);
+
+    const mappedStream = stream.map((x: number) => x * 2);
+
+    const expected1 = [0, 2, 4];
+    const expected2 = [0, 2, 4];
+
+    mappedStream.addListener({
+      next: (x: number) => {
+        assert.strictEqual(x, expected1.shift());
+      },
+      error: (e: any) => void 0,
+      complete: () => {
+        assert.strictEqual(expected1.length, 0);
+      }
+    });
+
+    setTimeout(() => {
+      mappedStream.addListener({
+      next: (x: number) => {
+        assert.strictEqual(x, expected2.shift());
+      },
+      error: (e: any) => void 0,
+      complete: () => {
+        assert.strictEqual(expected2.length, 0);
+        done();
+      }
+    });
+    }, 80);
+  });
 });

--- a/tests/operator/fold.ts
+++ b/tests/operator/fold.ts
@@ -41,4 +41,29 @@ describe('Stream.prototype.fold', () => {
       },
     });
   });
+
+  it('should return a stream with memory by default', (done) => {
+    const stream = xs.periodic(100).take(3).fold((x: number, y: number) => x + y, 0);
+
+    const expected1 = [0, 0, 1, 3];
+    const expected2 = [0, 1, 3];
+
+    stream.addListener({
+      next: (x: number) => {
+        assert.strictEqual(expected1.shift(), x);
+      },
+      error: done,
+      complete: () => void 0
+    });
+
+    setTimeout(() => {
+      stream.addListener({
+      next: (x: number) => {
+        assert.strictEqual(expected2.shift(), x);
+      },
+      error: done,
+      complete: () => done()
+    });
+    }, 150)
+  });
 });

--- a/tests/operator/imitate.ts
+++ b/tests/operator/imitate.ts
@@ -37,6 +37,16 @@ describe('MimicStream.prototype.imitate', () => {
     proxyStream.imitate(stream);
   });
 
+  it('should throw and error if given a stream with Memory', () => {
+    const proxy = xs.createMimic<number>();
+
+    const real = xs.of(1).remember();
+
+    assert.throws(() => {
+      proxy.imitate(real);
+    });
+  });
+
 //   it('should link the given stream to the mimic stream', (done) => {
 //     const stream = xs.periodic(50).take(3);
 //     const proxyStream = xs.createMimic<number>();

--- a/tests/operator/startWith.ts
+++ b/tests/operator/startWith.ts
@@ -13,4 +13,29 @@ describe('Stream.prototype.startWith', () => {
       complete: done
     });
   });
+
+  it('should return a stream with memory by default', (done) => {
+    const stream = xs.periodic(100).take(3).startWith(1);
+
+    const expected1 = [1, 0, 1, 2];
+    const expected2 = [0, 1, 2];
+
+    stream.addListener({
+      next: (x: number) => {
+        assert.strictEqual(expected1.shift(), x);
+      },
+      error: done,
+      complete: () => void 0
+    });
+
+    setTimeout(() => {
+      stream.addListener({
+      next: (x: number) => {
+        assert.strictEqual(expected2.shift(), x);
+      },
+      error: done,
+      complete: () => done()
+    });
+    }, 150)
+  });
 });


### PR DESCRIPTION
This removes the need for a separate type MemoryStream.

This PR is a WIP, the goal is make a larger working distinction between streams with memory (Signals) and streams that do not have memory (Events).