### PR TITLE
feat(Observable): [WIP] add Observable implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "url": "https://github.com/staltz/xstream/issues"
   },
   "homepage": "https://github.com/staltz/xstream#readme",
-  "dependencies": {},
+  "dependencies": {
+    "symbol-observable": "^0.2.4"
+  },
   "devDependencies": {
     "assert": "^1.3.0",
     "browserify": "^13.0.0",

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,4 +1,5 @@
 import {Promise} from 'es6-promise';
+import $$observable from 'symbol-observable';
 
 const empty = {};
 function noop() {}
@@ -999,6 +1000,20 @@ export class Stream<T> implements InternalListener<T> {
     this._remove(<InternalListener<T>> (<any> listener));
   }
 
+  /**
+   * Adds a Listener to the Stream
+   * 
+   * @param {Listener<T>} listener
+   * @returns {Subscription}
+   */
+  subscribe(listener: Listener<T>): Subscription<T> {
+    return new Subscription(this, listener);
+  }
+
+  [$$observable](): Observable<T> {
+    return Observable.fromStream(this);
+  }
+
   _add(il: InternalListener<T>): void {
     const a = this._ils;
     a.push(il);
@@ -1153,6 +1168,16 @@ export class Stream<T> implements InternalListener<T> {
    */
   static of<T>(...items: Array<T>): Stream<T> {
     return Stream.fromArray(items);
+  }
+
+  static from<T>(item: Observable<T> | Array<T> | Promise<T>): Stream<T> {
+    if (typeof item[$$observable] === 'function') {
+      return new Stream<T>(new FromObservableProducer(<Observable<T>> item));
+    } else if (typeof (<Promise<T>> item).then === 'function') {
+      return Stream.fromPromise<T>(<Promise<T>>item);
+    } else {
+      return Stream.fromArray<T>(<Array<T>> item);
+    }
   }
 
   /**
@@ -1758,6 +1783,81 @@ export class MemoryStream<T> extends Stream<T> {
 
   debug(labelOrSpy?: string | ((t: T) => void)): MemoryStream<T> {
     return <MemoryStream<T>> super.debug(labelOrSpy);
+  }
+}
+
+class FromObservableProducer<T> implements InternalProducer<T> {
+  private subscription: Subscription<T> = void 0;
+  constructor (private observable: Observable<T>) {
+  }
+
+  _start (out: InternalListener<T>) {
+    this.subscription = this.observable.subscribe({
+      next: x => out._n(x),
+      error: e => out._e(e),
+      complete: () => out._c()
+    });
+  }
+
+  _stop () {
+    if (this.subscription !== void 0) {
+      this.subscription.unsubscribe();
+    }
+  }
+}
+
+export class Subscription<T> {
+  private _isUnsubscribed: boolean = false;
+  constructor (private _stream: Stream<T>, private _listener: Listener<T>) {
+    _stream.addListener(_listener);
+  }
+
+  unsubscribe() {
+    this._isUnsubscribed = true;
+    this._stream.removeListener(this._listener);
+  }
+
+  get closed () {
+    return this._isUnsubscribed;
+  }
+}
+
+export type DisposeFn = () => void;
+export type Subscriber<T> = (listener: Listener<T>) => void | DisposeFn;
+
+export class Observable<T> extends Stream<T> {
+  constructor(private subscriber: Subscriber<T>) {
+    super(new ObservableProducer<T>(subscriber));
+  }
+
+  static fromStream<T>(stream: Stream<T>): Observable<T> {
+    return new Observable<T>((listener: Listener<T>) => {
+      stream.addListener(listener);
+
+      return () => stream.removeListener(listener);
+    });
+  }
+}
+
+class ObservableProducer<T> implements InternalProducer<T> {
+  private unsubscribe: void | DisposeFn;
+  constructor (private subscriber: Subscriber<T>) {
+    this.unsubscribe = void 0;
+  }
+
+  _start (out: InternalListener<T>) {
+    this.unsubscribe = this.subscriber({
+      next: x => out._n(x),
+      error: e => out._e(e),
+      complete: () => out._c()
+    });
+  }
+
+  _stop() {
+    if (typeof this.unsubscribe !== void 0) {
+      const unsubscribe: DisposeFn = <DisposeFn> this.unsubscribe;
+      unsubscribe();
+    }
   }
 }
 

--- a/src/custom-typings/symbol-observable.d.ts
+++ b/src/custom-typings/symbol-observable.d.ts
@@ -1,0 +1,2 @@
+declare const observableSymbol: symbol;
+export default observableSymbol;

--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,8 @@
 {
   "name": "xstream",
-  "dependencies": {},
+  "dependencies": {
+    "symbol-observable": "file:src/custom-typings/symbol-observable.d.ts"
+  },
   "devDependencies": {},
   "globalDependencies": {
     "es6-promise": "registry:dt/es6-promise#0.0.0+20160423074304"


### PR DESCRIPTION
Implements bi-directional conversion between Stream and Observable
and implements a .subscribe() method which returns a Subscription
type as defined by the current Observable specification

TODO
- [ ] Add tests for subscribe()
- [ ] Add tests for Stream.prototype\[symbol.observable\]()
- [ ] Add tests for Stream.from()
- [ ] Add Observable Tests
- [ ] Add Observable.fromStream() Tests
- [ ] Add Subscription Tests
- [ ] Add Documentation