### PR TITLE
refactor(doctest): Use markdown-doctest regexRequire to load extras

### DIFF
--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -31,11 +31,13 @@ class FakeEventTarget {
 
 module.exports = {
   require: {
-    xstream: xstream,
-    'xstream/extra/fromEvent': require('./extra/fromEvent').default,
-    'xstream/extra/delay': require('./extra/delay').default,
-    'xstream/extra/concat': require('./extra/concat').default,
-    'xstream/extra/fromDiagram': require('./extra/fromDiagram').default,
+    xstream: xstream
+  },
+
+  regexRequire: {
+    'xstream/extra/(.*)': function (_, extra) {
+      return require('./extra/' + extra).default;
+    }
   },
 
   globals: {


### PR DESCRIPTION
Saves anyone having to manually add any in future