### PR TITLE
Add browser console playground

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,3 +2,21 @@
   <div class="wrapper">
   </div>
 </footer>
+<script src="//raw.githubusercontent.com/staltz/xstream/master/dist/xstream.min.js"></script>
+<script>
+  window.xs = xstream.default;
+  //<![CDATA[
+  console.log(
+    '           _                             \n'+
+    ' __  _____| |_ _ __ ___  __ _ _ __ ___   \n'+
+    ' \\ \\/ / __| __| \'__/ _ \\/ _` | \'_ ` _ \\  \n'+
+    '  >  <\\__ \\ |_| | |  __/ (_| | | | | | | \n'+
+    ' /_/\\_\\___/\\__|_|  \\___|\\__,_|_| |_| |_| \n'+
+    '\n'+
+    '> console.log(xstream);'
+  );
+  console.log(xstream);
+  console.log('> console.log(xs)');
+  console.log(xs);
+  //]]>
+</script>


### PR DESCRIPTION
I'm used to play with the library and prototype at the browser console on it's site (e.g. [Ramda](http://ramdajs.com/docs/), [Moment](http://momentjs.com/), [Immutable](https://facebook.github.io/immutable-js/)). So the workflow is simple: check docs, open browser console, try it.
[xstream docs](http://staltz.com/xstream/) currently lacks this feature
This PR exposes `xstream` and `xs` to the global window object. It also adds nice console banner (shamefully based on the immutable one)

<img width="832" alt="preview" src="https://cloud.githubusercontent.com/assets/554231/15958040/243f53e2-2f04-11e6-8805-2e9c8df0443c.png">