### PR TITLE
Support NodeJS Event Emitters in fromEvent extra

### DIFF
--- a/src/extra/fromEvent.ts
+++ b/src/extra/fromEvent.ts
@@ -102,7 +102,9 @@ export class NodeEventProducer implements InternalProducer<any> {
  * dispatched to any EventTarget beneath it in the DOM tree. Defaults to false.
  * @return {Stream}
  */
-export default function fromEvent( element: EventTarget | EventEmitter, eventName: string, useCapture: boolean = false): Stream<Event|any> {
+export default function fromEvent( element: EventTarget | EventEmitter,
+                                   eventName: string,
+                                   useCapture: boolean = false): Stream<Event|any> {
   if ( element instanceof EventEmitter ) {
     return new Stream<any>(new NodeEventProducer( element, eventName ));
   } else {

--- a/src/extra/fromEvent.ts
+++ b/src/extra/fromEvent.ts
@@ -40,7 +40,7 @@ export class NodeEventProducer implements InternalProducer<any> {
 }
 
 function isEmitter(element: any): boolean {
-    return element.addListener;
+    return element.emit && element.addListener;
 }
 
 /**

--- a/tests/extra/fromEvent.ts
+++ b/tests/extra/fromEvent.ts
@@ -1,7 +1,6 @@
 /// <reference path="../../typings/globals/mocha/index.d.ts" />
 /// <reference path="../../typings/globals/node/index.d.ts" />
 import {EventEmitter} from 'events';
-import xs from '../../src/index';
 import fromEvent from '../../src/extra/fromEvent';
 import * as assert from 'assert';
 function noop() {};
@@ -79,8 +78,8 @@ describe('fromEvent (extra) - DOMEvent', () => {
 
     stream.addListener({next: noop, error: noop, complete: noop});
 
-    assert.strictEqual('test', target.event);
-    assert.strictEqual(true, target.capture);
+    assert.strictEqual(target.event, 'test');
+    assert.strictEqual(target.capture, true);
   });
 
   it('should call addEventListener with expected parameters', () => {
@@ -89,8 +88,8 @@ describe('fromEvent (extra) - DOMEvent', () => {
 
     stream.addListener({next: noop, error: noop, complete: noop});
 
-    assert.strictEqual('test', target.event);
-    assert.strictEqual(false, target.capture);
+    assert.strictEqual(target.event, 'test');
+    assert.strictEqual(target.capture, false);
   });
 
   it('should propagate events', (done) => {
@@ -125,8 +124,8 @@ describe('fromEvent (extra) - DOMEvent', () => {
       error: (err: any) => done(err),
       complete() {
         setTimeout(() => {
-          assert.strictEqual('test', target.removedEvent);
-          assert.strictEqual(true, target.removedCapture);
+          assert.strictEqual(target.removedEvent, 'test');
+          assert.strictEqual(target.removedCapture, true);
           done();
         }, 5);
       }
@@ -144,7 +143,7 @@ describe('fromEvent (extra) - EventEmitter', () => {
 
     stream.addListener({next: noop, error: noop, complete: noop});
 
-    assert.strictEqual('test', target.event);
+    assert.strictEqual(target.event, 'test');
   });
 
   it('should propagate events', (done) => {
@@ -179,7 +178,7 @@ describe('fromEvent (extra) - EventEmitter', () => {
       error: (err: any) => done(err),
       complete() {
         setTimeout(() => {
-          assert.strictEqual('test', target.removedEvent);
+          assert.strictEqual(target.removedEvent, 'test');
           done();
         }, 5);
       }

--- a/tests/extra/fromEvent.ts
+++ b/tests/extra/fromEvent.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../typings/globals/mocha/index.d.ts" />
 /// <reference path="../../typings/globals/node/index.d.ts" />
+import {EventEmitter} from 'events';
 import xs from '../../src/index';
 import fromEvent from '../../src/extra/fromEvent';
 import * as assert from 'assert';
@@ -39,7 +40,39 @@ class FakeEventTarget implements EventTarget {
   }
 };
 
-describe('fromEvent (extra)', () => {
+class FakeEventEmitter extends EventEmitter {
+  public handler: Function;
+  public event: string;
+  public removedEvent: string;
+
+  constructor() {
+    super();
+  }
+
+  emit( eventName: string, ...args: any[] ): any {
+    if (typeof this.handler !== 'function') {
+        return;
+    }
+    this.handler.apply(void 0, args );
+    return true;
+  }
+
+  addListener(e: string, handler: Function): FakeEventEmitter {
+    this.event = e;
+    this.handler = handler;
+    return this;
+  }
+
+  removeListener(e: string, handler: Function): FakeEventEmitter {
+    this.removedEvent = e;
+
+    this.handler = this.event = void 0;
+    return this;
+  }
+
+};
+
+describe('fromEvent (extra) - DOMEvent', () => {
   it('should call addEventListener with expected parameters', () => {
     const target = new FakeEventTarget();
     const stream = fromEvent(target, 'test', true);
@@ -101,5 +134,58 @@ describe('fromEvent (extra)', () => {
 
     target.emit(1);
     target.emit(2);
+  });
+});
+
+describe('fromEvent (extra) - EventEmitter', () => {
+  it('should call addListener with expected parameters', () => {
+    const target = new FakeEventEmitter();
+    const stream = fromEvent(target, 'test');
+
+    stream.addListener({next: noop, error: noop, complete: noop});
+
+    assert.strictEqual('test', target.event);
+  });
+
+  it('should propagate events', (done) => {
+    const target = new FakeEventEmitter();
+    const stream = fromEvent(target, 'test').take(3);
+
+    let expected = [1, 2, 3];
+
+    stream.addListener({
+      next: (x: any) => {
+        assert.strictEqual(x, expected.shift());
+      },
+      error: (err: any) => done(err),
+      complete: () => {
+        assert.strictEqual(expected.length, 0);
+        done();
+      }
+    });
+
+    target.emit( 'test', 1 );
+    target.emit( 'test', 2 );
+    target.emit( 'test', 3 );
+    target.emit( 'test', 4 );
+  });
+
+  it('should call removeListener with expected parameters', (done) => {
+    const target = new FakeEventEmitter();
+    const stream = fromEvent(target, 'test');
+
+    stream.take(1).addListener({
+      next: (x) => {},
+      error: (err: any) => done(err),
+      complete() {
+        setTimeout(() => {
+          assert.strictEqual('test', target.removedEvent);
+          done();
+        }, 5);
+      }
+    });
+
+    target.emit( 'test', 1 );
+    target.emit( 'test', 2 );
   });
 });


### PR DESCRIPTION
Add support for stream generation from EventEmitters. 

## Description
`fromEvent` will accept as a first argument either a DOMElement or an EventEmitter. When providing `fromEvent` with an EventEmitter, the third argument (useCapture) is always ignored.

There are two potentially outstanding concerns.

**First**: This is my first contribution to xtream and I'm not familiar with how the documentation is built. I've updated JSDOC comments with new examples, but it's possible that my comments don't work with the documentation generator.
**Second**: Parity with RxJS and Most.js should probably involve a change to the third parameter here. I believe they support an object with configuration options, rather than a boolean. I'm not certain if that work would be a requirement to merge, but a brief discussion probably couldn't hurt. I'm happy to update the implementation to accommodate any updated signatures.

## Motivation and Context
This should resolve staltz/xstream#65.

## How Has This Been Tested?
Tests have been split between the two possible uses of the extra and are passing.

## Checklist:
- [x] My code follows the code style of this project. (I think so?)
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. (I've done some work, but need to confirm)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.