### PR TITLE
fix xs.merge completion

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -83,16 +83,16 @@ function and<T>(f1: (t: T) => boolean, f2: (t: T) => boolean): (t: T) => boolean
 export class MergeProducer<T> implements Aggregator<T, T>, InternalListener<T> {
   public type = 'merge';
   public out: Stream<T> = null;
-  private ac: number; // ac is activeCount, starts initialized
+  private ac: number; // ac is activeCount
 
   constructor(public insArr: Array<Stream<T>>) {
-    this.ac = insArr.length;
   }
 
   _start(out: Stream<T>): void {
     this.out = out;
     const s = this.insArr;
     const L = s.length;
+    this.ac = L;
     for (let i = 0; i < L; i++) {
       s[i]._add(this);
     }
@@ -105,7 +105,6 @@ export class MergeProducer<T> implements Aggregator<T, T>, InternalListener<T> {
       s[i]._remove(this);
     }
     this.out = null;
-    this.ac = L;
   }
 
   _n(t: T) {
@@ -121,7 +120,7 @@ export class MergeProducer<T> implements Aggregator<T, T>, InternalListener<T> {
   }
 
   _c() {
-    if (--this.ac === 0) {
+    if (--this.ac <= 0) {
       const u = this.out;
       if (!u) return;
       u._c();


### PR DESCRIPTION
This is intended to fix #74 

The problem it that case is that `MergeProducer#_stop` method never gets called because of cancelled async stoppage. So when original stream gets executed second time and then completed, the `ac` counter goes to -1 and that doesn't lead to merged stream completion.

The idea of PR is that we can be sure about (virtual) count of active listeners right before we iterate through `insArr` and call `_add`s, because each of the incoming streams either runs already or gets started by `_add`.

There's still a potential problem in case if some incoming stream gets restarted by another listener. To fix that, `merge` should be rewritten in the manner of `combine` to track which of the streams actually completes.