### PR TITLE
Introduce xs.merge type declaration

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -132,6 +132,37 @@ export class MergeProducer<T> implements Aggregator<T, T>, InternalListener<T> {
   }
 }
 
+export interface MergeSignature {
+  (): Stream<any>;
+  <T1>(s1: Stream<T1>): Stream<T1>;
+  <T1, T2>(
+    s1: Stream<T1>,
+    s2: Stream<T2>): Stream<T1 | T2>;
+  <T1, T2, T3>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>): Stream<T1 | T2 | T3>;
+  <T1, T2, T3, T4>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>): Stream<T1 | T2 | T3 | T4>;
+  <T1, T2, T3, T4, T5>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>): Stream<T1 | T2 | T3 | T4 | T5>;
+  <T1, T2, T3, T4, T5, T6>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>): Stream<T1 | T2 | T3 | T4 | T5 | T6>;
+  <T>(...stream: Array<Stream<T>>): Stream<T>;
+}
+
 export interface CombineSignature {
   (): Stream<Array<any>>;
   <T1>(s1: Stream<T1>): Stream<[T1]>;
@@ -1377,9 +1408,10 @@ export class Stream<T> implements InternalListener<T> {
    * or more streams may be given as arguments.
    * @return {Stream}
    */
-  static merge<T>(...streams: Array<Stream<T>>): Stream<T> {
-    return new Stream<T>(new MergeProducer(streams));
-  }
+  static merge: MergeSignature = <MergeSignature>
+    function merge(...streams: Array<Stream<any>>): Stream<any> {
+      return new Stream<any>(new MergeProducer(streams));
+    };
 
   /**
    * Combines multiple input streams together to return a stream whose events

--- a/tests/factory/merge.ts
+++ b/tests/factory/merge.ts
@@ -75,4 +75,25 @@ describe('xs.merge', () => {
     assert.strictEqual(stream instanceof Stream, true);
     done();
   });
+
+  it('should have a correct TypeScript signature', () => {
+    const bools = xs.create<boolean>({
+      start: listener => {},
+      stop: () => {}
+    });
+
+    const numbers = xs.create<number>({
+      start: listener => {},
+      stop: () => {}
+    });
+
+    const strings = xs.create<string>({
+      start: listener => {},
+      stop: () => {}
+    });
+
+    const emptyIsh: Stream<boolean> = xs.merge<boolean>();
+    const doubled: Stream<boolean | string> = xs.merge(bools, strings);
+    const tripled: Stream<boolean | number | string> = xs.merge(bools, strings, numbers);
+  });
 });


### PR DESCRIPTION
Support type declarations when calling `xs.merge()`. This change allows consumers to leverage TypeScript to verify type safety when merging streams. It also brings `merge` in line with other static methods which already support this feature.

## Description
Modify static `merge` method to implement a new interface: MergeSignature. This interface is constructed similarly to the CombineSignature interface. Export the new interface.

There are two areas I think merit discussion.

**First**: I'm not exactly sure what the intended behavior of this method is when called without arguments. The interface says a stream is returned that emits items of any type. And I suppose that's true. However, when I call this without any arguments, I get a stream that doesn't emit anything ever (or complete). Obviously my fault as the caller, but perhaps we want to do something else when it's called without arguments.

**Second**: I don't know how to test this or if it deserves a test. I imported core into a test file and was able to get type support for the method.

## Motivation and Context
This should resolve staltz/xstream#80.

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.