### PR TITLE
feat(fromEvent): Aggregate multiple arguments

### DIFF
--- a/tests/extra/fromEvent.ts
+++ b/tests/extra/fromEvent.ts
@@ -187,4 +187,25 @@ describe('fromEvent (extra) - EventEmitter', () => {
     target.emit( 'test', 1 );
     target.emit( 'test', 2 );
   });
+
+  it('should aggregate arguments from emitters', (done) => {
+    const target = new FakeEventEmitter();
+    const stream = fromEvent(target, 'test').take(2);
+
+    let expected = [[1, 'foo', true], [2, 'bar', false]];
+
+    stream.addListener({
+      next: (x: any) => {
+        assert.deepEqual(x, expected.shift());
+      },
+      error: (err: any) => done(err),
+      complete: () => {
+        assert.strictEqual(expected.length, 0);
+        done();
+      }
+    });
+
+    target.emit( 'test', 1, 'foo', true );
+    target.emit( 'test', 2, 'bar', false );
+  });
 });


### PR DESCRIPTION
If provided with an EventEmitter, `fromEvent` streams will emit an array of values when the EventEmitter provides listeners with multiple arguments.

## Description
The previous implementation naively provided only the first argument, which made `fromEvent` incompatible with event interfaces that rely on providing multiple arguments to their listeners, such as Node's `http.Server`.

An alternative solution involved providing selector support. This wasn't implemented for several reasons.

  1. Modifying the function signature for the extra would be a breaking change.
  2. An expanded function signature would become 'crowded', and one of the architectural goals of xstream is to keep interfaces as small as they need to be to achieve their goals.
  3. Aggregating emitted events into an array is consistent with the implementation in Most.js, and achieves similar flexibility with Rx when providing a selector function to `.map()` on a result stream.

`fromEvent` will now emit mixed-types. **If consumers are not responsible for calling `.emit()` on the source emitter, they should implement appropriate guards to ensure they are dealing with an intended type.**

I think that it would be great if `fromEvent` could support typed EventEmitters so that downstream consumers could rely on TypeScript to warn them about guards, but EventEmitter isn't a generic type and that would take some rejiggering that I didn't think was warranted to implement this feature.

## Motivation and Context
This should resolve staltz/xstream#84.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.