### PR TITLE
fix(dropRepeats): handle circular dependencies

### DIFF
--- a/src/extra/dropRepeats.ts
+++ b/src/extra/dropRepeats.ts
@@ -29,10 +29,9 @@ export class DropRepeatsOperator<T> implements Operator<T, T> {
     const u = this.out;
     if (!u) return;
     const v = this.v;
-    if (v === empty || !this.isEq(t, v)) {
-      u._n(t);
-    }
+    if (v !== empty && this.isEq(t, v)) return;
     this.v = t;
+    u._n(t);
   }
 
   _e(err: any) {

--- a/tests/extra/dropRepeats.ts
+++ b/tests/extra/dropRepeats.ts
@@ -37,4 +37,29 @@ describe('dropRepeats (extra)', () => {
       },
     });
   });
+
+  it('should drop consecutive duplicate numbers, with a circular stream dependency', (done) => {
+    const streamProxy = xs.create();
+    const input = xs.of(0, 0, 1, 1, 1)
+    const stream = xs.merge(streamProxy, input).compose(dropRepeats());
+    streamProxy.imitate(stream);
+    const expected = [0, 1];
+
+    stream.addListener({
+      next: (x: number) => {
+        assert.equal(x, expected.shift());
+      },
+      error: (err: any) => done(err),
+      complete: () => {},
+    });
+
+    input.addListener({
+      next: (x: number) => {},
+      error: (err: any) => done(err),
+      complete: () => {
+        assert.equal(expected.length, 0);
+        done();
+      },
+    });
+  });
 });


### PR DESCRIPTION
Ran into a tricky behavior tonight when feeding @cycle/history into itself: if we have a circular dependency, and the event emitted by `dropRepeats` triggers another input event in the same stream, we can get into an infinite loop. The `dropRepeats` operator will recurse because it emits before it updates its sentinel value until it overflows the stack.

This test seems to model the case I hit accurately, but the way it checks for completion feels a bit inelegant -- any suggestions? I tried using `endWith(input.last())` but that appeared to cause `stream` to complete without emitting any events.