### PR TITLE
support type-guards in Stream's filter method

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1543,6 +1543,8 @@ export class Stream<T> implements InternalListener<T> {
    * boolean.
    * @return {Stream}
    */
+  filter<S extends T>(passes: (t: T) => t is S): Stream<S>;
+  filter(passes: (t: T) => boolean): Stream<T>;
   filter(passes: (t: T) => boolean): Stream<T> {
     const p = this._prod;
     if (p instanceof FilterOperator) {


### PR DESCRIPTION
If a type-guard is passed to filter, you know that the returned stream contains
only elements of the type that is checked by the type-guard.