### PR TITLE
docs(README): document filter operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ var xs = require('xstream').default
 - [`removeListener`](#removeListener)
 - [`map`](#map)
 - [`mapTo`](#mapTo)
+- [`filter`](#filter)
 - [`take`](#take)
 - [`drop`](#drop)
 - [`last`](#last)
@@ -506,6 +507,32 @@ Marble diagram:
 #### Arguments:
 
 - `projectedValue` A value to emit on the output Stream whenever the input Stream emits any value.
+
+#### Returns:  Stream 
+
+- - -
+
+### <a id="filter"></a> `filter(passes)`
+
+Only allows events that pass the test given by the `passes` argument.
+
+Each event from the input stream is given to the `passes` function. If the
+function returns `true`, the event is forwarded to the output stream,
+otherwise it is ignored and not forwarded.
+
+Marble diagram:
+
+```text
+--1---2--3-----4-----5---6--7-8--
+    filter(i => i % 2 === 0)
+------2--------4---------6----8--
+```
+
+#### Arguments
+
+- `passes` A function of type `(t: T) => boolean` that takes
+an event from the input stream and checks if it passes, by returning a
+boolean.
 
 #### Returns:  Stream 
 


### PR DESCRIPTION
I noticed the documentation for the `filter` operator was missing in `README`, so I copied it over from the [source](https://github.com/staltz/xstream/blob/master/src/core.ts#L1526-L1545).