### PR TITLE
feat(Observable): Adds Basic Observable interop

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "markdox": "^0.1.10",
     "mkdirp": "^0.5.1",
     "mocha": "^2.4.5",
+    "most": "^1.0.3",
     "sinon": "^1.16.0",
     "strip-comments": "^0.4.4",
     "ts-node": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "url": "https://github.com/staltz/xstream/issues"
   },
   "homepage": "https://github.com/staltz/xstream#readme",
-  "dependencies": {},
+  "dependencies": {
+    "symbol-observable": "^1.0.2"
+  },
   "devDependencies": {
     "assert": "^1.3.0",
     "browserify": "^13.0.0",

--- a/src/core.ts
+++ b/src/core.ts
@@ -57,7 +57,11 @@ export interface Listener<T> {
   complete: () => void;
 }
 
-export type FromInput<T> = Promise<T> | Stream<T> | Array<T>
+export type Observable<T> = {
+  subscribe(listener: Listener<T>): { unsubscribe: () => void; }
+}
+
+export type FromInput<T> = Promise<T> | Stream<T> | Array<T> | Observable<T>;
 
 // mutates the input
 function internalizeProducer<T>(producer: Producer<T>) {

--- a/src/core.ts
+++ b/src/core.ts
@@ -1067,7 +1067,7 @@ class ObservableProducer<T> implements InternalProducer<T> {
   public type = 'fromObservable';
   public ins: any;
   public out: Stream<T>;
-  private _unsusbcribe: () => void;
+  private _subscription: { unsubscribe: () => void; };
 
   constructor (observable: any) {
     this.ins = observable;
@@ -1075,11 +1075,11 @@ class ObservableProducer<T> implements InternalProducer<T> {
 
   _start (out: Stream<T>) {
     this.out = out;
-    this._unsusbcribe = this.ins.subscribe(new ObservableListener(out));
+    this._subscription = this.ins.subscribe(new ObservableListener(out));
   }
 
   _stop () {
-    this._unsusbcribe();
+    this._subscription.unsubscribe();
   }
 }
 
@@ -2111,7 +2111,7 @@ export class MemoryStream<T> extends Stream<T> {
   }
 }
 
-class Subscription<T> {
+export class Subscription<T> {
   constructor (private _stream: Stream<T>, private _listener: Listener<T>) {}
 
   unsubscribe (): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-import {Stream, MemoryStream, Listener, Producer, Operator} from './core';
-export {Stream, MemoryStream, Listener, Producer, Operator};
+import {Stream, MemoryStream, Listener, Producer, Operator, Observable} from './core';
+export {Stream, MemoryStream, Listener, Producer, Operator, Observable};
 export default Stream;

--- a/tests/factory/from.ts
+++ b/tests/factory/from.ts
@@ -1,0 +1,73 @@
+/// <reference path="../../typings/globals/mocha/index.d.ts" />
+/// <reference path="../../typings/globals/node/index.d.ts" />
+import {Promise} from 'es6-promise';
+import xs, { Observable } from '../../src/index';
+import * as assert from 'assert';
+import * as most from 'most';
+
+describe('xs.from', () => {
+  it('should convert a resolved promise to a stream', (done) => {
+    const stream = xs.from(Promise.resolve('yes'));
+    let nextSent = false;
+
+    stream.addListener({
+      next: (x: string) => {
+        assert.strictEqual(x, 'yes');
+        nextSent = true;
+      },
+      error: (err: any) => done(err),
+      complete: () => {
+        assert.strictEqual(nextSent, true);
+        done();
+      },
+    });
+  });
+
+  it('should convert a rejected promise to a stream', (done) => {
+    const stream = xs.from(Promise.reject('no'));
+
+    stream.addListener({
+      next: (x: string) => done('next should not be called'),
+      error: (err: any) => {
+        assert.strictEqual(err, 'no');
+        done();
+      },
+      complete: () => done('complete should not be called'),
+    });
+  });
+
+  it('should convert an array to a stream', (done) => {
+    const stream = xs.from([10, 20, 30, 40, 50])
+      .map(i => String(i));
+    let expected = ['10', '20', '30', '40', '50'];
+
+    stream.addListener({
+      next: (x: string) => {
+        assert.equal(x, expected.shift());
+      },
+      error: (err: any) => done(err),
+      complete: () => {
+        assert.equal(expected.length, 0);
+        done();
+      },
+    });
+  });
+
+  it('should convert an observable to a stream', (done) => {
+    const observable = most.from<number>([10, 20, 30, 40, 50]);
+    const stream = xs.from(observable as Observable<number>)
+      .map(i => String(i));
+    let expected = ['10', '20', '30', '40', '50'];
+
+    stream.addListener({
+      next: (x: string) => {
+        assert.equal(x, expected.shift());
+      },
+      error: (err: any) => done(err),
+      complete: () => {
+        assert.equal(expected.length, 0);
+        done();
+      },
+    });
+  });
+});

--- a/tests/factory/fromObservable.ts
+++ b/tests/factory/fromObservable.ts
@@ -1,0 +1,26 @@
+/// <reference path="../../typings/globals/mocha/index.d.ts" />
+/// <reference path="../../typings/globals/node/index.d.ts" />
+import xs from '../../src/index';
+import * as assert from 'assert';
+
+import * as most from 'most';
+
+describe('xs.fromObservable', () => {
+  it('should convert an observable to a stream', (done) => {
+    const observable = most.from([10, 20, 30, 40, 50]);
+    const stream = xs.fromObservable(observable)
+      .map(i => String(i));
+    let expected = ['10', '20', '30', '40', '50'];
+
+    stream.addListener({
+      next: (x: string) => {
+        assert.equal(x, expected.shift());
+      },
+      error: (err: any) => done(err),
+      complete: () => {
+        assert.equal(expected.length, 0);
+        done();
+      },
+    });
+  });
+});

--- a/tests/stream.ts
+++ b/tests/stream.ts
@@ -484,6 +484,8 @@ describe('Stream', () => {
 
       assert.equal(typeof subscription, 'object');
       assert.equal(typeof subscription.unsubscribe, 'function');
+
+      done();
     });
   });
 });

--- a/tests/stream.ts
+++ b/tests/stream.ts
@@ -13,6 +13,7 @@ describe('Stream', () => {
     assert.equal(typeof xs.of, 'function');
     assert.equal(typeof xs.fromArray, 'function');
     assert.equal(typeof xs.fromPromise, 'function');
+    assert.equal(typeof xs.fromObservable, 'function');
     assert.equal(typeof xs.periodic, 'function');
     assert.equal(typeof xs.merge, 'function');
     assert.equal(typeof xs.combine, 'function');
@@ -22,6 +23,7 @@ describe('Stream', () => {
     const stream = xs.create();
     assert.equal(typeof stream.addListener, 'function');
     assert.equal(typeof stream.removeListener, 'function');
+    assert.equal(typeof stream.subscribe, 'function');
     assert.equal(typeof stream.map, 'function');
     assert.equal(typeof stream.mapTo, 'function');
     assert.equal(typeof stream.filter, 'function');

--- a/tests/stream.ts
+++ b/tests/stream.ts
@@ -11,6 +11,7 @@ describe('Stream', () => {
     assert.equal(typeof xs.empty, 'function');
     assert.equal(typeof xs.throw, 'function');
     assert.equal(typeof xs.of, 'function');
+    assert.equal(typeof xs.from, 'function');
     assert.equal(typeof xs.fromArray, 'function');
     assert.equal(typeof xs.fromPromise, 'function');
     assert.equal(typeof xs.fromObservable, 'function');

--- a/tests/stream.ts
+++ b/tests/stream.ts
@@ -410,4 +410,80 @@ describe('Stream', () => {
       }
     });
   });
+
+  describe('subscribe', () => {
+     it('throws a helpful error if you forget the next function', (done) => {
+      const stream = xs.empty();
+      const listener = <Listener<Number>> <any> {};
+
+      try {
+        stream.subscribe(listener);
+      } catch (e) {
+        assert.equal(e.message, 'stream.addListener() requires all three ' +
+        'next, error, and complete functions.');
+        done();
+      }
+    });
+
+    it('throws a helpful error if you forget the error function', (done) => {
+      const stream = xs.empty();
+      const listener = <Listener<Number>> <any> {
+        next: (x: any) => {}
+      };
+
+      try {
+        stream.subscribe(listener);
+      } catch (e) {
+        assert.equal(e.message, 'stream.addListener() requires all three ' +
+        'next, error, and complete functions.');
+        done();
+      }
+    });
+
+    it('throws a helpful error if you forget the complete function', (done) => {
+      const stream = xs.empty();
+      const listener = <Listener<Number>> <any> {
+        next: (x: any) => {},
+        error: (err: any) => {}
+      };
+
+      try {
+        stream.subscribe(listener);
+      } catch (e) {
+        assert.equal(e.message, 'stream.addListener() requires all three ' +
+        'next, error, and complete functions.');
+        done();
+      }
+    });
+
+    it('throws a helpful error if you pass a non function value as the next function', (done) => {
+      const stream = xs.empty();
+      const listener = <Listener<Number>> <any> {
+        next: undefined
+      };
+
+      try {
+        stream.subscribe(listener);
+      } catch (e) {
+        assert.equal(e.message, 'stream.addListener() requires all three ' +
+        'next, error, and complete functions.');
+        done();
+      }
+    });
+
+    it('should return a subscription', (done) => {
+      const stream = xs.empty();
+      const noop = (): void => void 0;
+      const listener = {
+        next: noop,
+        error: noop,
+        complete: noop
+      };
+
+      const subscription = stream.subscribe(listener);
+
+      assert.equal(typeof subscription, 'object');
+      assert.equal(typeof subscription.unsubscribe, 'function');
+    });
+  });
 });


### PR DESCRIPTION
Implements basic interop that is compatible with most.js and RxJS 5. 
Add `xs.fromObservable(observable)` method that will take an Observable and return an xstream `Stream`.
Add `xs.from(input)` for Observable interop, which will convert Arrays, Observable, and Promises using their respective fromX method.
Add `subscribe` method to Stream that return a Subscription with `unsubscribe`
Add `Symbol.observable` ponyfill `symbol-observable` as a dependency to use the same as most.js and RxJS 5.
Add tests for all of the above.