### PR TITLE
Throw error if no listener is attached #121

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1189,6 +1189,7 @@ export class Stream<T> implements InternalListener<T> {
       const b = copy(a);
       for (let i = 0; i < L; i++) b[i]._e(err);
     }
+    if (!this._d && L == 0) throw this._err;
   }
 
   _c(): void {

--- a/tests/operator/imitate.ts
+++ b/tests/operator/imitate.ts
@@ -220,7 +220,7 @@ describe('Stream.prototype.imitate', () => {
       return xs.of(1).compose(delay<number>(20));
     }).flatten();
     proxyAction$.imitate(action$);
-    const expected = [0, 1, 2];
+    const expected = [0, 1, 2, 3];
 
     let errors: Array<any> = [];
     state$.addListener({


### PR DESCRIPTION
This prevents `Stream` from swallowing errors if no `Listener` is attached.
