### PR TITLE
Implement `sampleCombine` extra

### DIFF
--- a/markdown/footer.md
+++ b/markdown/footer.md
@@ -16,12 +16,14 @@ A: Read this [blog post](http://staltz.com/why-we-built-xstream.html) on the top
 
 **Q: What is the equivalent of [`withLatestFrom`](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-withLatestFrom) in xstream?**
 
+`withLatestFrom` is implemented as an extra named [`sampleCombine`](https://github.com/staltz/xstream/blob/master/EXTRA_DOCS.md#sampleCombine). It may also be composed with existing operators:
+
 <!-- skip-example -->
 ```js
 A.withLatestFrom(B, (a, b) => a + b)
 ```
 
-can be achieved in *xstream* with
+can be composed in *xstream* with
 
 ```js
 B.map(b => A.map(a => a + b)).flatten()

--- a/src/core.ts
+++ b/src/core.ts
@@ -227,7 +227,7 @@ export interface MergeSignature {
     s5: Stream<T5>,
     s6: Stream<T6>,
     s7: Stream<T7>,
-    s8: Stream<T7>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
+    s8: Stream<T8>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
   <T1, T2, T3, T4, T5, T6, T7, T8, T9>(
     s1: Stream<T1>,
     s2: Stream<T2>,
@@ -236,8 +236,8 @@ export interface MergeSignature {
     s5: Stream<T5>,
     s6: Stream<T6>,
     s7: Stream<T7>,
-    s8: Stream<T7>,
-    s9: Stream<T7>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
+    s8: Stream<T8>,
+    s9: Stream<T9>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
   <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
     s1: Stream<T1>,
     s2: Stream<T2>,
@@ -246,9 +246,9 @@ export interface MergeSignature {
     s5: Stream<T5>,
     s6: Stream<T6>,
     s7: Stream<T7>,
-    s8: Stream<T7>,
-    s9: Stream<T7>,
-    s10: Stream<T7>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10>;
+    s8: Stream<T8>,
+    s9: Stream<T9>,
+    s10: Stream<T10>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10>;
   <T>(...stream: Array<Stream<T>>): Stream<T>;
 }
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -280,6 +280,44 @@ export interface CombineSignature {
     s4: Stream<T4>,
     s5: Stream<T5>,
     s6: Stream<T6>): Stream<[T1, T2, T3, T4, T5, T6]>;
+  <T1, T2, T3, T4, T5, T6, T7>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>): Stream<[T1, T2, T3, T4, T5, T6, T7]>;
+  <T1, T2, T3, T4, T5, T6, T7, T8>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>,
+    s8: Stream<T8>): Stream<[T1, T2, T3, T4, T5, T6, T7, T8]>;
+  <T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>,
+    s8: Stream<T8>,
+    s9: Stream<T9>): Stream<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
+  <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>,
+    s8: Stream<T8>,
+    s9: Stream<T9>,
+    s10: Stream<T10>): Stream<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;
   (...stream: Array<Stream<any>>): Stream<Array<any>>;
 }
 

--- a/src/extra/sampleCombine.ts
+++ b/src/extra/sampleCombine.ts
@@ -1,0 +1,155 @@
+import {CombineSignature, InternalListener, Operator, Stream} from '../core';
+
+export class SampleCombineListener<T> implements InternalListener<T> {
+    constructor(private i: number, private p: SampleCombineOperator<any>) {
+        p.ils[i] = this;
+    }
+
+    _n(t: T): void {
+        if (!this.p.out) return;
+        this.p.vals[this.i] = t;
+    }
+
+    _e(err: any): void {
+        this.p._e(err);
+    }
+
+    _c(): void {
+        this.p.d(this.i, this);
+    }
+}
+
+export class SampleCombineOperator<T> implements Operator<T, Array<any>> {
+  public type = 'sampleCombine';
+  public out: Stream<Array<any>>;
+  public vals: Array<any> = [];
+  public Sc: number = 0;
+  public ils: Array<SampleCombineListener<any>> = [];
+
+  constructor(public ins: Stream<T>,
+              public streams: Array<Stream<any>>) {}
+
+  _start(out: Stream<Array<any>>): void {
+      if (!this.ins || !this.streams) {
+          out._n([]);
+          out._c();
+      } else {
+          this.Sc = this.streams.length;
+          this.ins._add(this);
+          this.out = out;
+          if (this.Sc) {
+              for (let i = 0; i < this.Sc; i++) {
+                  this.vals[i] = undefined;
+                  this.streams[i]._add(new SampleCombineListener<any>(i, this));
+              }
+          }
+      }
+  }
+
+  _stop(): void {
+      if (!this.ins || this.Sc) return;
+      this.ins._remove(this);
+      this.out = this.vals = null;
+      for (let i = 0; i < this.Sc; i++) {
+        this.streams[i]._remove(this.ils[i]);
+      }
+  }
+
+  _n(t: T): void {
+      if (!this.out) return;
+      this.out._n([t, ...this.vals]);
+  }
+
+  _e(err: any): void {
+      if (!this.out) return;
+      this.out._e(err);
+  }
+
+  _c(): void {
+      if (!this.out) return;
+      this.out._c();
+  }
+
+  d(i: number, l: SampleCombineListener<any>): void {
+      this.streams[i]._remove(l);
+  }
+}
+
+/**
+ * Combines a source stream with multiple other streams. The result stream
+ * will emit the latest events from all input streams, but only when the
+ * source stream emits.
+ *
+ * If the source, or any input stream, throws an error, the result stream
+ * will propagate the error. If any input streams end, their final emitted
+ * value will remain in the array of any subsequent events from the result
+ * stream.
+ *
+ * The result stream will only complete upon completion of the source stream.
+ *
+ * Marble diagram:
+ *
+ * ```text
+ * --1----2-----3--------4---
+ * ----a-----b-----c--d------
+ *      sampleCombine
+ * --1?---2a----3b-------4d--
+ * ```
+ *
+ * Examples:
+ *
+ * ```js
+ * import sampleCombine from 'xstream/extra/sampleCombine'
+ * import xs from 'xstream'
+ *
+ * const sampler = xs.periodic(1000).take(3)
+ * const other = xs.periodic(100)
+ *
+ * const stream = sampleCombine(sampler, other)
+ *
+ * stream.addListener({
+ *   next: i => console.log(i),
+ *   error: err => console.error(err),
+ *   complete: () => console.log('completed')
+ * })
+ * ```
+ *
+ * ```text
+ * > [0, 8]
+ * > [1, 18]
+ * > [2, 28]
+ * ```
+ *
+ * ```js
+ * import sampleCombine from 'xstream/extra/sampleCombine'
+ * import xs from 'xstream'
+ *
+ * const sampler = xs.periodic(1000).take(3)
+ * const other = xs.periodic(100).take(2)
+ *
+ * const stream = sampleCombine(sampler, other)
+ *
+ * stream.addListener({
+ *   next: i => console.log(i),
+ *   error: err => console.error(err),
+ *   complete: () => console.log('completed')
+ * })
+ * ```
+ *
+ * ```text
+ * > [0, 1]
+ * > [1, 1]
+ * > [2, 1]
+ * ```
+ *
+ * @param {Stream} sampler The source stream of which to sample.
+ * @param {...Stream} streams One or more streams to combine.
+ * @return {Stream}
+ */
+let sampleCombine: CombineSignature;
+sampleCombine = function(sampler: Stream<any>,
+                         ...streams: Array<Stream<any>>): Stream<Array<any>> {
+    return new Stream<Array<any>>(new SampleCombineOperator<any>(sampler, streams));
+} as CombineSignature;
+
+export default sampleCombine;

--- a/tests/extra/sampleCombine.ts
+++ b/tests/extra/sampleCombine.ts
@@ -1,0 +1,162 @@
+/// <reference path="../../typings/globals/mocha/index.d.ts" />
+/// <reference path="../../typings/globals/node/index.d.ts" />
+import xs, {Stream} from '../../src/index';
+import sampleCombine from '../../src/extra/sampleCombine';
+import * as assert from 'assert';
+
+describe('sampleCombine (extra)', () => {
+  it('should combine AND-style two streams together', (done) => {
+    const stream1 = xs.periodic(100).take(3);
+    const stream2 = xs.periodic(99).take(3);
+    const stream = sampleCombine(stream1, stream2);
+    let expected = [[0, 0], [1, 1], [2, 2]];
+    stream.addListener({
+      next: (x) => {
+        const e = expected.shift();
+        assert.equal(x[0], e[0]);
+        assert.equal(x[1], e[1]);
+      },
+      error: done,
+      complete: () => {
+        assert.equal(expected.length, 0);
+        done();
+      },
+    });
+  });
+
+  it('should have correct TypeScript signature', (done) => {
+    const stream1 = xs.create<string>({
+      start: listener => {},
+      stop: () => {}
+    });
+
+    const stream2 = xs.create<string>({
+      start: listener => {},
+      stop: () => {}
+    });
+
+    const combined: Stream<[string, string]> = sampleCombine(stream1, stream2);
+    done();
+  });
+
+  it('should complete only when the sample stream has completed', (done) => {
+    const stream1 = xs.periodic(100).take(4);
+    const stream2 = xs.periodic(99).take(1);
+    const stream = sampleCombine(stream1, stream2).map(arr => arr.join(''));
+    let expected = ['00', '10', '20', '30'];
+    stream.addListener({
+      next: (x) => {
+        assert.equal(x, expected.shift());
+      },
+      error: done,
+      complete: () => {
+        assert.equal(expected.length, 0);
+        done();
+      },
+    });
+  });
+
+  it('should emit an empty array if combining zero streams', (done) => {
+    const stream = sampleCombine();
+
+    stream.addListener({
+      next: (a) => {
+        assert.equal(Array.isArray(a), true);
+        assert.equal(a.length, 0);
+      },
+      error: done,
+      complete: () => {
+        done();
+      },
+    });
+  });
+
+  it('should just wrap the value if combining one stream', (done) => {
+    const source = xs.periodic(100).take(3);
+    const stream = sampleCombine(source);
+    let expected = [[0], [1], [2]];
+
+    stream.addListener({
+      next: (x) => {
+        const e = expected.shift();
+        assert.equal(x[0], e[0]);
+      },
+      error: done,
+      complete: () => {
+        assert.equal(expected.length, 0);
+        done();
+      },
+    });
+  });
+
+  it('should not break future listeners when SampleCombineProducer tears down', (done) => {
+    //     --0---1--2---|  innerA
+    //     ----0----1---|  innerB
+    // ----0-----1--2---|  outer
+    // ------00--11-12--|  stream
+    const innerA = xs.create<number>();
+    const innerB = xs.create<number>();
+    const outer = xs.create<number>();
+    const arrayInners: Array<Stream<number>> = [];
+    const stream = outer
+      .map(x => {
+        return sampleCombine(...arrayInners)
+          .map(combination => `${x}${combination.join('')}`);
+      })
+      .flatten();
+    const expected = ['00', '11', '12'];
+
+    setTimeout(() => {
+      arrayInners.push(innerA);
+      outer.shamefullySendNext(0);
+    }, 100);
+    setTimeout(() => {
+      innerA.shamefullySendNext(0);
+    }, 150);
+    setTimeout(() => {
+      innerB.shamefullySendNext(0);
+    }, 175);
+    setTimeout(() => {
+      arrayInners.push(innerB);
+      outer.shamefullySendNext(1);
+      innerA.shamefullySendNext(1);
+    }, 200);
+    setTimeout(() => {
+      innerA.shamefullySendNext(2);
+      outer.shamefullySendNext(2);
+      innerB.shamefullySendNext(1);
+    }, 250);
+    setTimeout(() => {
+      innerA.shamefullySendComplete();
+      innerB.shamefullySendComplete();
+      outer.shamefullySendComplete();
+    }, 550);
+
+    stream.addListener({
+      next: (x: string) => {
+        assert.equal(x, expected.shift());
+      },
+      error: (err: any) => done(err),
+      complete: () => {
+        assert.equal(expected.length, 0);
+        done();
+      },
+    });
+  });
+
+  it('should return a Stream when combining a MemoryStream with a Stream', (done) => {
+    const input1 = xs.periodic(80).take(4).remember();
+    const input2 = xs.periodic(50).take(3);
+    const stream: Stream<[number, number]> = sampleCombine(input1, input2);
+    assert.strictEqual(stream instanceof Stream, true);
+    done();
+  });
+
+  it('should return a Stream when combining a MemoryStream with a MemoryStream', (done) => {
+    const input1 = xs.periodic(80).take(4).remember();
+    const input2 = xs.periodic(50).take(3).remember();
+    const stream: Stream<[number, number]> = sampleCombine(input1, input2);
+    assert.strictEqual(stream instanceof Stream, true);
+    done();
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     "src/extra/fromDiagram.ts",
     "src/extra/fromEvent.ts",
     "src/extra/pairwise.ts",
+    "src/extra/sampleCombine.ts",
     "src/extra/split.ts",
     "src/extra/tween.ts",
     "src/index.ts"


### PR DESCRIPTION
Add an extra named `sampleCombine`. This extra is designed to provide parity with the [`withLatestFrom`](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-withLatestFrom) operator, and similar operators, in other stream libraries.

## Description
SampleCombine combines a source stream with multiple other streams. The result stream will emit the latest events from all input streams, but only when the source stream emits.

If the source, or any input stream, throws an error, the result stream will propagate the error. If any input streams end, their final emitted value will remain in the array of any subsequent events from the result stream (this behavior is consistent with the implementation in Rx). The result stream will only complete upon completion of the source stream.

This extra operator implements the CombineSignature core interface.

Fixes #102.
Related to #97.

Additionally, I've included a bug fix for variadic types in `MergeSignature`, and implemented similar expanded types for `CombineSignature`. Neither of those changes are required for the extra to function.

## Motivation and Context
`withLatestFrom` has been a tricky operator to explain and compose for many `xstream` users, as demonstrated in #102 and #97.

This extra aims to make implementing the kind of functionality achievable with `withLatestFrom` straightforward. No selector support is introduced here, but users can select items using `filter` or `map` on a result stream.

## How Has This Been Tested?
My implementation for the operator borrowed heavily from `CombineProducer` and implements `CombineSignature`. I've implemented all of the same tests for `combine` in `sampleCombine`.

The `should not break future listeners` test for `combine` may not actually be relevant for this extra, but I included it anyway. I believe that the test is supposed to verify that a teardown step in a producer does not create errors later in a combine lifecycle. I think my test verifies this, but I can make changes if needed.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.