### PR TITLE
improve TypeScript typings for delay, dropRepeats, dropUnti, split

### DIFF
--- a/src/extra/delay.ts
+++ b/src/extra/delay.ts
@@ -85,8 +85,8 @@ class DelayOperator<T> implements Operator<T, T> {
  * @param {number} period The amount of silence required in milliseconds.
  * @return {Stream}
  */
-export default function delay<T>(period: number): (ins: Stream<T>) => Stream<T> {
-  return function delayOperator(ins: Stream<T>): Stream<T> {
+export default function delay(period: number): <T>(ins: Stream<T>) => Stream<T> {
+  return function delayOperator<T>(ins: Stream<T>): Stream<T> {
     return new Stream<T>(new DelayOperator(period, ins));
   };
 }

--- a/src/extra/dropRepeats.ts
+++ b/src/extra/dropRepeats.ts
@@ -112,8 +112,8 @@ export class DropRepeatsOperator<T> implements Operator<T, T> {
  * checks if it is equal to previous event, by returning a boolean.
  * @return {Stream}
  */
-export default function dropRepeats<T>(isEqual: (x: T, y: T) => boolean = null): (ins: Stream<T>) => Stream<T> {
-  return function dropRepeatsOperator(ins: Stream<T>): Stream<T> {
-    return new Stream<T>(new DropRepeatsOperator(isEqual, ins));
+export default function dropRepeats<T>(isEqual: <T>(x: T, y: T) => boolean = null): <T>(ins: Stream<T>) => Stream<T> {
+  return function dropRepeatsOperator<T>(ins: Stream<T>): Stream<T> {
+    return new Stream<T>(new DropRepeatsOperator<T>(isEqual, ins));
   };
 }

--- a/src/extra/dropUntil.ts
+++ b/src/extra/dropUntil.ts
@@ -110,8 +110,8 @@ export class DropUntilOperator<T> implements Operator<T, T> {
  * output stream of this operator start emitting.
  * @return {Stream}
  */
-export default function dropUntil<T>(other: Stream<any>): (ins: Stream<T>) => Stream<T> {
-  return function dropUntilOperator(ins: Stream<T>): Stream<T> {
+export default function dropUntil(other: Stream<any>): <T>(ins: Stream<T>) => Stream<T> {
+  return function dropUntilOperator<T>(ins: Stream<T>): Stream<T> {
     return new Stream<T>(new DropUntilOperator(other, ins));
   };
 }

--- a/src/extra/split.ts
+++ b/src/extra/split.ts
@@ -128,8 +128,8 @@ export class SplitOperator<T> implements Operator<T, Stream<T>> {
  * split the output stream.
  * @return {Stream}
  */
-export default function split<T>(separator: Stream<any>): (ins: Stream<T>) => Stream<Stream<T>> {
-  return function splitOperator(ins: Stream<T>): Stream<Stream<T>> {
+export default function split(separator: Stream<any>): <T>(ins: Stream<T>) => Stream<Stream<T>> {
+  return function splitOperator<T>(ins: Stream<T>): Stream<Stream<T>> {
     return new Stream<Stream<T>>(new SplitOperator(separator, ins));
   };
 }

--- a/tests/extra/dropUntil.ts
+++ b/tests/extra/dropUntil.ts
@@ -26,7 +26,7 @@ describe('dropUntil (extra)', () => {
 
   it('should complete the stream when another stream emits complete', (done) => {
     const source = xs.periodic(50).take(6);
-    const other = xs.empty().compose(delay<any>(220));
+    const other = xs.empty().compose(delay(220));
     const stream = source.compose(dropUntil(other));
     const expected = [4, 5];
 

--- a/tests/operator/endWhen.ts
+++ b/tests/operator/endWhen.ts
@@ -25,7 +25,7 @@ describe('Stream.prototype.endWhen', () => {
 
   it('should complete the stream when another stream emits complete', (done) => {
     const source = xs.periodic(50);
-    const other = xs.empty().compose(delay<any>(220));
+    const other = xs.empty().compose(delay(220));
     const stream = source.endWhen(other);
     const expected = [0, 1, 2, 3];
 

--- a/tests/operator/imitate.ts
+++ b/tests/operator/imitate.ts
@@ -8,7 +8,7 @@ describe('Stream.prototype.imitate', () => {
   it('should be able to model a circular dependency in the stream graph', (done) => {
     const secondMimic = xs.create<number>();
     const first = secondMimic.map(x => x * 10).take(3);
-    const second = first.map(x => x + 1).startWith(1).compose(delay<number>(1));
+    const second = first.map(x => x + 1).startWith(1).compose(delay(1));
     secondMimic.imitate(second);
     const expected = [1, 11, 111, 1111];
 
@@ -27,7 +27,7 @@ describe('Stream.prototype.imitate', () => {
   it('should be able to model a circular dependency, mimic subscribed', (done) => {
     const secondMimic = xs.create<number>();
     const first = secondMimic.map(x => x * 10).take(3);
-    const second = first.map(x => x + 1).startWith(1).compose(delay<number>(1));
+    const second = first.map(x => x + 1).startWith(1).compose(delay(1));
     secondMimic.imitate(second);
     const expected = [1, 11, 111, 1111];
 
@@ -46,7 +46,7 @@ describe('Stream.prototype.imitate', () => {
   it('should broadcast the source stream to multiple listeners', (done) => {
     const fakeSecond = xs.create<number>();
     const first = fakeSecond.map(x => x * 10).take(3);
-    const second = first.map(x => x + 1).startWith(1).compose(delay<number>(100));
+    const second = first.map(x => x + 1).startWith(1).compose(delay(100));
     fakeSecond.imitate(second);
 
     const expected1 = [1, 11, 111, 1111];
@@ -160,7 +160,7 @@ describe('Stream.prototype.imitate', () => {
     const outside = xs.periodic(150);
     const secondMimic = xs.create<number>();
     const first = xs.merge(outside, secondMimic.map(x => x * 10));
-    const second = first.map(x => x + 1).compose(delay<number>(100));
+    const second = first.map(x => x + 1).compose(delay(100));
     secondMimic.imitate(second);
     const expectedSecond1 = [1];
     const expectedSecond4 = [1, 11, 2, 111];
@@ -217,7 +217,7 @@ describe('Stream.prototype.imitate', () => {
       if (state === 3) {
         throw new Error(':(');
       }
-      return xs.of(1).compose(delay<number>(20));
+      return xs.of(1).compose(delay(20));
     }).flatten();
     proxyAction$.imitate(action$);
     const expected = [0, 1, 2];


### PR DESCRIPTION
A little bit breaking because `delay` doesn't not allow to specify type, so one will have to fix it in the codebase.