### PR TITLE
Extracted factory interfaces (signatures) from main index.ts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ index.d.ts
 index.js
 index.js.map
 /extra/
+/factory/
 
 # Generated directories
 .sass-cache/

--- a/src/factory/signature/combineSignature.ts
+++ b/src/factory/signature/combineSignature.ts
@@ -1,0 +1,70 @@
+import {Stream} from '../../index';
+
+export interface CombineSignature {
+  (): Stream<Array<any>>;
+  <T1>(s1: Stream<T1>): Stream<[T1]>;
+  <T1, T2>(
+    s1: Stream<T1>,
+    s2: Stream<T2>): Stream<[T1, T2]>;
+  <T1, T2, T3>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>): Stream<[T1, T2, T3]>;
+  <T1, T2, T3, T4>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>): Stream<[T1, T2, T3, T4]>;
+  <T1, T2, T3, T4, T5>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>): Stream<[T1, T2, T3, T4, T5]>;
+  <T1, T2, T3, T4, T5, T6>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>): Stream<[T1, T2, T3, T4, T5, T6]>;
+  <T1, T2, T3, T4, T5, T6, T7>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>): Stream<[T1, T2, T3, T4, T5, T6, T7]>;
+  <T1, T2, T3, T4, T5, T6, T7, T8>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>,
+    s8: Stream<T8>): Stream<[T1, T2, T3, T4, T5, T6, T7, T8]>;
+  <T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>,
+    s8: Stream<T8>,
+    s9: Stream<T9>): Stream<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
+  <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>,
+    s8: Stream<T8>,
+    s9: Stream<T9>,
+    s10: Stream<T10>): Stream<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;
+  (...stream: Array<Stream<any>>): Stream<Array<any>>;
+}

--- a/src/factory/signature/index.ts
+++ b/src/factory/signature/index.ts
@@ -1,0 +1,2 @@
+export {CombineSignature} from './combineSignature'
+export {MergeSignature} from './mergeSignature'

--- a/src/factory/signature/mergeSignature.ts
+++ b/src/factory/signature/mergeSignature.ts
@@ -1,0 +1,70 @@
+import {Stream} from '../../index';
+
+export interface MergeSignature {
+  (): Stream<any>;
+  <T1>(s1: Stream<T1>): Stream<T1>;
+  <T1, T2>(
+    s1: Stream<T1>,
+    s2: Stream<T2>): Stream<T1 | T2>;
+  <T1, T2, T3>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>): Stream<T1 | T2 | T3>;
+  <T1, T2, T3, T4>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>): Stream<T1 | T2 | T3 | T4>;
+  <T1, T2, T3, T4, T5>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>): Stream<T1 | T2 | T3 | T4 | T5>;
+  <T1, T2, T3, T4, T5, T6>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>): Stream<T1 | T2 | T3 | T4 | T5 | T6>;
+  <T1, T2, T3, T4, T5, T6, T7>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7>;
+  <T1, T2, T3, T4, T5, T6, T7, T8>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>,
+    s8: Stream<T8>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
+  <T1, T2, T3, T4, T5, T6, T7, T8, T9>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>,
+    s8: Stream<T8>,
+    s9: Stream<T9>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
+  <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
+    s1: Stream<T1>,
+    s2: Stream<T2>,
+    s3: Stream<T3>,
+    s4: Stream<T4>,
+    s5: Stream<T5>,
+    s6: Stream<T6>,
+    s7: Stream<T7>,
+    s8: Stream<T8>,
+    s9: Stream<T9>,
+    s10: Stream<T10>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10>;
+  <T>(...stream: Array<Stream<T>>): Stream<T>;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import $$observable from 'symbol-observable';
+import {CombineSignature, MergeSignature} from './factory/signature';
 
 const NO = {};
 function noop() {}
@@ -150,75 +151,6 @@ class FromObservable<T> implements InternalProducer<T> {
   }
 }
 
-export interface MergeSignature {
-  (): Stream<any>;
-  <T1>(s1: Stream<T1>): Stream<T1>;
-  <T1, T2>(
-    s1: Stream<T1>,
-    s2: Stream<T2>): Stream<T1 | T2>;
-  <T1, T2, T3>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>): Stream<T1 | T2 | T3>;
-  <T1, T2, T3, T4>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>): Stream<T1 | T2 | T3 | T4>;
-  <T1, T2, T3, T4, T5>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>): Stream<T1 | T2 | T3 | T4 | T5>;
-  <T1, T2, T3, T4, T5, T6>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>,
-    s6: Stream<T6>): Stream<T1 | T2 | T3 | T4 | T5 | T6>;
-  <T1, T2, T3, T4, T5, T6, T7>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>,
-    s6: Stream<T6>,
-    s7: Stream<T7>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7>;
-  <T1, T2, T3, T4, T5, T6, T7, T8>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>,
-    s6: Stream<T6>,
-    s7: Stream<T7>,
-    s8: Stream<T8>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
-  <T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>,
-    s6: Stream<T6>,
-    s7: Stream<T7>,
-    s8: Stream<T8>,
-    s9: Stream<T9>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
-  <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>,
-    s6: Stream<T6>,
-    s7: Stream<T7>,
-    s8: Stream<T8>,
-    s9: Stream<T9>,
-    s10: Stream<T10>): Stream<T1 | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9 | T10>;
-  <T>(...stream: Array<Stream<T>>): Stream<T>;
-}
-
 class Merge<T> implements Aggregator<T, T>, InternalListener<T> {
   public type = 'merge';
   public insArr: Array<Stream<T>>;
@@ -269,75 +201,6 @@ class Merge<T> implements Aggregator<T, T>, InternalListener<T> {
       u._c();
     }
   }
-}
-
-export interface CombineSignature {
-  (): Stream<Array<any>>;
-  <T1>(s1: Stream<T1>): Stream<[T1]>;
-  <T1, T2>(
-    s1: Stream<T1>,
-    s2: Stream<T2>): Stream<[T1, T2]>;
-  <T1, T2, T3>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>): Stream<[T1, T2, T3]>;
-  <T1, T2, T3, T4>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>): Stream<[T1, T2, T3, T4]>;
-  <T1, T2, T3, T4, T5>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>): Stream<[T1, T2, T3, T4, T5]>;
-  <T1, T2, T3, T4, T5, T6>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>,
-    s6: Stream<T6>): Stream<[T1, T2, T3, T4, T5, T6]>;
-  <T1, T2, T3, T4, T5, T6, T7>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>,
-    s6: Stream<T6>,
-    s7: Stream<T7>): Stream<[T1, T2, T3, T4, T5, T6, T7]>;
-  <T1, T2, T3, T4, T5, T6, T7, T8>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>,
-    s6: Stream<T6>,
-    s7: Stream<T7>,
-    s8: Stream<T8>): Stream<[T1, T2, T3, T4, T5, T6, T7, T8]>;
-  <T1, T2, T3, T4, T5, T6, T7, T8, T9>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>,
-    s6: Stream<T6>,
-    s7: Stream<T7>,
-    s8: Stream<T8>,
-    s9: Stream<T9>): Stream<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>;
-  <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(
-    s1: Stream<T1>,
-    s2: Stream<T2>,
-    s3: Stream<T3>,
-    s4: Stream<T4>,
-    s5: Stream<T5>,
-    s6: Stream<T6>,
-    s7: Stream<T7>,
-    s8: Stream<T8>,
-    s9: Stream<T9>,
-    s10: Stream<T10>): Stream<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>;
-  (...stream: Array<Stream<any>>): Stream<Array<any>>;
 }
 
 class CombineListener<T> implements InternalListener<T>, OutSender<Array<T>> {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,8 +29,8 @@
     "src/extra/delay.ts",
     "src/extra/dropRepeats.ts",
     "src/extra/dropUntil.ts",
-    "src/extra/flattenSequentially.ts",
     "src/extra/flattenConcurrently.ts",
+    "src/extra/flattenSequentially.ts",
     "src/extra/fromDiagram.ts",
     "src/extra/fromEvent.ts",
     "src/extra/pairwise.ts",
@@ -38,6 +38,9 @@
     "src/extra/split.ts",
     "src/extra/throttle.ts",
     "src/extra/tween.ts",
+    "src/factory/signature/combineSignature.ts",
+    "src/factory/signature/index.ts",
+    "src/factory/signature/mergeSignature.ts",
     "src/index.ts"
   ],
   "filesGlob": [


### PR DESCRIPTION
I would like to help on extracting some possible dependencies on the index.ts file.

For a first commit, I suggest to extract the two factories interfaces (signatures): MergeSignature and  CombineSignature.

Since we only have two, I think the best approach is to have a signatures directory inside factory, like this:
src/factory/signature
-combineSignature
-mergeSignature

I used camelCase on the file naming and factory/signature on singular as it's being used as a pattern on the other files/directories.

PS: I prefer the organization above rather then something like:
factory/combine/combineSignature.ts
factory/merge/mergeSignature.ts

The reason in my opinion is that we can have less imports (only one in index.ts) and we only have these signatures.

Let me know if I can keep refactoring to help with PR's like this.