### PR TITLE
fix(extra): Simplify extra operator generics

### DIFF
--- a/src/extra/buffer.ts
+++ b/src/extra/buffer.ts
@@ -104,8 +104,8 @@ class BufferOperator<T> implements Operator<T, Array<T>> {
  * split the output stream.
  * @return {Stream}
  */
-export default function buffer(s: Stream<any>): <T>(ins: Stream<T>) => Stream<Array<T>> {
-  return function bufferOperator<T>(ins: Stream<T>) {
+export default function buffer<T>(s: Stream<any>): (ins: Stream<T>) => Stream<Array<T>> {
+  return function bufferOperator(ins: Stream<T>) {
     return new Stream<Array<T>>(new BufferOperator<T>(s, ins));
   };
 }

--- a/src/extra/debounce.ts
+++ b/src/extra/debounce.ts
@@ -90,8 +90,8 @@ class DebounceOperator<T> implements Operator<T, T> {
  * @param {number} period The amount of silence required in milliseconds.
  * @return {Stream}
  */
-export default function debounce(period: number): <T>(ins: Stream<T>) => Stream<T> {
-  return function debounceOperator<T>(ins: Stream<T>) {
+export default function debounce<T>(period: number): (ins: Stream<T>) => Stream<T> {
+  return function debounceOperator(ins: Stream<T>) {
     return new Stream<T>(new DebounceOperator(period, ins));
   };
 }

--- a/src/extra/dropRepeats.ts
+++ b/src/extra/dropRepeats.ts
@@ -112,8 +112,8 @@ export class DropRepeatsOperator<T> implements Operator<T, T> {
  * checks if it is equal to previous event, by returning a boolean.
  * @return {Stream}
  */
-export default function dropRepeats(isEqual: (<T>(x: T, y: T) => boolean) | undefined = void 0): <T>(ins: Stream<T>) => Stream<T> {
-  return function dropRepeatsOperator<T>(ins: Stream<T>): Stream<T> {
+export default function dropRepeats<T>(isEqual: ((x: T, y: T) => boolean) | undefined = void 0): (ins: Stream<T>) => Stream<T> {
+  return function dropRepeatsOperator(ins: Stream<T>): Stream<T> {
     return new Stream<T>(new DropRepeatsOperator<T>(ins, isEqual));
   };
 }

--- a/src/extra/dropUntil.ts
+++ b/src/extra/dropUntil.ts
@@ -110,8 +110,8 @@ export class DropUntilOperator<T> implements Operator<T, T> {
  * output stream of this operator start emitting.
  * @return {Stream}
  */
-export default function dropUntil(other: Stream<any>): <T>(ins: Stream<T>) => Stream<T> {
-  return function dropUntilOperator<T>(ins: Stream<T>): Stream<T> {
+export default function dropUntil<T>(other: Stream<any>): (ins: Stream<T>) => Stream<T> {
+  return function dropUntilOperator(ins: Stream<T>): Stream<T> {
     return new Stream<T>(new DropUntilOperator(other, ins));
   };
 }

--- a/src/extra/split.ts
+++ b/src/extra/split.ts
@@ -128,8 +128,8 @@ export class SplitOperator<T> implements Operator<T, Stream<T>> {
  * split the output stream.
  * @return {Stream}
  */
-export default function split(separator: Stream<any>): <T>(ins: Stream<T>) => Stream<Stream<T>> {
-  return function splitOperator<T>(ins: Stream<T>): Stream<Stream<T>> {
+export default function split<T>(separator: Stream<any>): (ins: Stream<T>) => Stream<Stream<T>> {
+  return function splitOperator(ins: Stream<T>): Stream<Stream<T>> {
     return new Stream<Stream<T>>(new SplitOperator(separator, ins));
   };
 }

--- a/src/extra/throttle.ts
+++ b/src/extra/throttle.ts
@@ -90,8 +90,8 @@ class ThrottleOperator<T> implements Operator<T, T> {
  * @param {number} period The amount of silence required in milliseconds.
  * @return {Stream}
  */
-export default function throttle(period: number): <T>(ins: Stream<T>) => Stream<T> {
-  return function throttleOperator<T>(ins: Stream<T>) {
+export default function throttle<T>(period: number): (ins: Stream<T>) => Stream<T> {
+  return function throttleOperator(ins: Stream<T>) {
     return new Stream<T>(new ThrottleOperator(period, ins));
   };
 }


### PR DESCRIPTION
Move the generic parameters of the extra operators to support better generic parameter inferencing in Typescript 2.4 while continuing to pass tests in Typescript 2.1. Delay is the only extra operator of this form skipped in this commit because it is the only one that didn't pass Typescript inferencing compile (in imitate tests) in Typescript 2.1 (though it builds in Typescript 2.4).

Resolves #202