### PR TITLE
perf(extra/dropRepeats): Optimize set equality check function only inside constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,21 +464,6 @@ Marble diagram:
 ----1a-2a-2b-3b-3c-3d-4d--
 ```
 
-Note: to minimize garbage collection, *combine* uses the same array
-instance for each emission.  If you need to compare emissions over time,
-cache the values with `map` first:
-
-```js
-import pairwise from 'xstream/extra/pairwise'
-
-const stream1 = xs.of(1);
-const stream2 = xs.of(2);
-
-xs.combine(stream1, stream2).map(
-  combinedEmissions => ([ ...combinedEmissions ])
-).compose(pairwise)
-```
-
 #### Arguments:
 
 - `stream1: Stream` A stream to combine together with other streams.

--- a/src/extra/dropRepeats.ts
+++ b/src/extra/dropRepeats.ts
@@ -4,10 +4,12 @@ const empty = {};
 export class DropRepeatsOperator<T> implements Operator<T, T> {
   public type = 'dropRepeats';
   public out: Stream<T> = null as any;
+  public isEq: (x: T, y: T) => boolean;
   private v: T = <any> empty;
 
   constructor(public ins: Stream<T>,
-              public fn: ((x: T, y: T) => boolean) | undefined) {
+              fn: ((x: T, y: T) => boolean) | undefined) {
+    this.isEq = typeof fn === 'function' ? fn : (x, y) => x === y;
   }
 
   _start(out: Stream<T>): void {
@@ -19,10 +21,6 @@ export class DropRepeatsOperator<T> implements Operator<T, T> {
     this.ins._remove(this);
     this.out = null as any;
     this.v = empty as any;
-  }
-
-  isEq(x: T, y: T) {
-    return this.fn ? this.fn(x, y) : x === y;
   }
 
   _n(t: T) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1486,21 +1486,6 @@ export class Stream<T> implements InternalListener<T> {
    * ----1a-2a-2b-3b-3c-3d-4d--
    * ```
    *
-   * Note: to minimize garbage collection, *combine* uses the same array
-   * instance for each emission.  If you need to compare emissions over time,
-   * cache the values with `map` first:
-   *
-   * ```js
-   * import pairwise from 'xstream/extra/pairwise'
-   *
-   * const stream1 = xs.of(1);
-   * const stream2 = xs.of(2);
-   *
-   * xs.combine(stream1, stream2).map(
-   *   combinedEmissions => ([ ...combinedEmissions ])
-   * ).compose(pairwise)
-   * ```
-   *
    * @factory true
    * @param {Stream} stream1 A stream to combine together with other streams.
    * @param {Stream} stream2 A stream to combine together with other streams.

--- a/tests/factory/combine.ts
+++ b/tests/factory/combine.ts
@@ -27,6 +27,27 @@ describe('xs.combine', () => {
     });
   });
 
+  it('should return new Array not reusing instance for each emission', (done: any) => {
+    const stream1 = xs.periodic(100).take(2);
+    const stream2 = xs.periodic(120).take(2);
+    const stream = xs.combine(stream1, stream2);
+    let expected = [0,0];
+    let last: any = undefined;
+    stream.addListener({
+      next: (x) => {
+        if (!last) last = x;
+        else assert.notStrictEqual(x, last, 'are same instance')
+      },
+      error: done,
+      complete: () => {
+        assert.notStrictEqual(last, undefined, 'must be 1st Array ([0,0])');
+        assert.equal(last[0],expected[0]);
+        assert.equal(last[1],expected[1]);
+        done();
+      },
+    });
+  });
+
   it('should have correct TypeScript signature', (done: any) => {
     const stream1 = xs.create<string>({
       start: listener => {},


### PR DESCRIPTION
Little optimization to extra/dropRepeats to set equality function only inside constructor, not
checking it on every call to isEq, plus some bytes saved in code and deleting an unused public
variable (this.fn) from class.