### PR TITLE
perf(extra/dropRepeats): Optimize set equality check function only inside constructor

### DIFF
--- a/src/extra/dropRepeats.ts
+++ b/src/extra/dropRepeats.ts
@@ -4,10 +4,12 @@ const empty = {};
 export class DropRepeatsOperator<T> implements Operator<T, T> {
   public type = 'dropRepeats';
   public out: Stream<T> = null as any;
+  public isEq: (x: T, y: T) => boolean;
   private v: T = <any> empty;
 
   constructor(public ins: Stream<T>,
-              public fn: ((x: T, y: T) => boolean) | undefined) {
+              fn: ((x: T, y: T) => boolean) | undefined) {
+    this.isEq = fn ? fn : (x, y) => x === y;
   }
 
   _start(out: Stream<T>): void {
@@ -19,10 +21,6 @@ export class DropRepeatsOperator<T> implements Operator<T, T> {
     this.ins._remove(this);
     this.out = null as any;
     this.v = empty as any;
-  }
-
-  isEq(x: T, y: T) {
-    return this.fn ? this.fn(x, y) : x === y;
   }
 
   _n(t: T) {


### PR DESCRIPTION
Little optimization to extra/dropRepeats to set equality function only inside constructor, not
checking it on every call to isEq, plus some bytes saved in code and deleting an unused public
variable (this.fn) from class.