### PR TITLE
refactor(time): Deprecate time based operators

### DIFF
--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -3,6 +3,8 @@ var eventsModule = require('events');
 
 function noop () {}
 
+console.warn = noop;
+
 class FakeEventTarget {
   constructor() {}
 
@@ -54,7 +56,8 @@ module.exports = {
     setInterval: noop,
     console: {
       log: noop,
-      error: noop
+      error: noop,
+      warn: noop
     },
     document: new FakeEventTarget(),
     listener: {

--- a/EXTRA_DOCS.md
+++ b/EXTRA_DOCS.md
@@ -16,6 +16,7 @@
 - [`sampleCombine`](#sampleCombine) (operator)
 - [`split`](#split) (operator)
 - [`throttle`](#throttle) (operator)
+- [`periodic`](#periodic) (factory)
 - [`tween`](#tween) (factory)
 
 # How to use extras
@@ -58,9 +59,10 @@ Example:
 
 ```js
 import buffer from 'xstream/extra/buffer'
+import periodic from 'xstream/extra/periodic';
 
-const source = xs.periodic(50).take(10);
-const separator = xs.periodic(170).take(3);
+const source = periodic(50).take(10);
+const separator = periodic(170).take(3);
 const buffered = source.compose(buffer(separator));
 
 buffered.addListener({
@@ -300,10 +302,11 @@ Example:
 
 ```js
 import dropUntil from 'xstream/extra/dropUntil'
+import periodic from 'xstream/extra/periodic';
 
-const other = xs.periodic(220).take(1)
+const other = periodic(220).take(1)
 
-const stream = xs.periodic(50)
+const stream = periodic(50)
   .take(6)
   .compose(dropUntil(other))
 
@@ -598,10 +601,11 @@ Examples:
 
 ```js
 import sampleCombine from 'xstream/extra/sampleCombine'
+import periodic from 'xstream/extra/periodic';
 import xs from 'xstream'
 
-const sampler = xs.periodic(1000).take(3)
-const other = xs.periodic(100)
+const sampler = periodic(1000).take(3)
+const other = periodic(100)
 
 const stream = sampler.compose(sampleCombine(other))
 
@@ -620,10 +624,11 @@ stream.addListener({
 
 ```js
 import sampleCombine from 'xstream/extra/sampleCombine'
+import periodic from 'xstream/extra/periodic';
 import xs from 'xstream'
 
-const sampler = xs.periodic(1000).take(3)
-const other = xs.periodic(100).take(2)
+const sampler = periodic(1000).take(3)
+const other = periodic(100).take(2)
 
 const stream = sampler.compose(sampleCombine(other))
 
@@ -670,9 +675,10 @@ Example:
 ```js
 import split from 'xstream/extra/split'
 import concat from 'xstream/extra/concat'
+import periodic from 'xstream/extra/periodic';
 
-const source = xs.periodic(50).take(10)
-const separator = concat(xs.periodic(167).take(2), xs.never())
+const source = periodic(50).take(10)
+const separator = concat(periodic(167).take(2), xs.never())
 const result = source.compose(split(separator))
 
 result.addListener({
@@ -753,6 +759,26 @@ stream.addListener({
 - `period: number` The amount of silence required in milliseconds.
 
 #### Returns:  Stream 
+
+- - -
+
+### <a id="periodic"></a> `periodic(period)`
+
+Creates a stream that periodically emits incremental numbers, every
+`period` milliseconds.
+
+Marble diagram:
+
+```text
+    periodic(1000)
+---0---1---2---3---4---...
+```
+
+#### Arguments:
+
+- `period: number` The interval in milliseconds to use as a rate of emission.
+
+#### Returns:  Stream
 
 - - -
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,16 @@ __  _____| |_ _ __ ___  __ _ _ __ ___
 
 ```js
 import xs from 'xstream'
+import periodic from 'xstream/extra/periodic';
 
 // Tick every second incremental numbers,
 // only pass even numbers, then map them to their square,
 // and stop after 5 seconds has passed
 
-var stream = xs.periodic(1000)
+var stream = periodic(1000)
   .filter(i => i % 2 === 0)
   .map(i => i * i)
-  .endWhen(xs.periodic(5000).take(1))
+  .endWhen(periodic(5000).take(1))
 
 // So far, the stream is idle.
 // As soon as it gets its first listener, it starts executing.
@@ -78,7 +79,6 @@ var xs = require('xstream').default
 - [`fromArray`](#fromArray)
 - [`fromPromise`](#fromPromise)
 - [`fromObservable`](#fromObservable)
-- [`periodic`](#periodic)
 - [`merge`](#merge)
 - [`combine`](#combine)
 
@@ -234,7 +234,7 @@ It's still useful to eventually (asynchronously) stop a Stream's internal Produc
 
 # Factories
 
-Factories are functions that create Streams, such as `xs.create()`, `xs.periodic()`, etc.
+Factories are functions that create Streams, such as `xs.create()`, `xs.merge()`, etc.
 
 ### <a id="create"></a> `create(producer)`
 
@@ -393,26 +393,6 @@ Converts an Observable into a Stream.
 #### Arguments:
 
 - `observable: any` The observable to be converted as a stream.
-
-#### Returns:  Stream 
-
-- - -
-
-### <a id="periodic"></a> `periodic(period)`
-
-Creates a stream that periodically emits incremental numbers, every
-`period` milliseconds.
-
-Marble diagram:
-
-```text
-    periodic(1000)
----0---1---2---3---4---...
-```
-
-#### Arguments:
-
-- `period: number` The interval in milliseconds to use as a rate of emission.
 
 #### Returns:  Stream 
 

--- a/markdown/header.md
+++ b/markdown/header.md
@@ -16,15 +16,16 @@
 
 ```js
 import xs from 'xstream'
+import periodic from 'xstream/extra/periodic';
 
 // Tick every second incremental numbers,
 // only pass even numbers, then map them to their square,
 // and stop after 5 seconds has passed
 
-var stream = xs.periodic(1000)
+var stream = periodic(1000)
   .filter(i => i % 2 === 0)
   .map(i => i * i)
-  .endWhen(xs.periodic(5000).take(1))
+  .endWhen(periodic(5000).take(1))
 
 // So far, the stream is idle.
 // As soon as it gets its first listener, it starts executing.

--- a/src/extra/debounce.ts
+++ b/src/extra/debounce.ts
@@ -7,6 +7,7 @@ class DebounceOperator<T> implements Operator<T, T> {
 
   constructor(public dt: number,
               public ins: Stream<T>) {
+    console.warn('All time based operators have been deprecated, please migrate to @cycle/time');
   }
 
   _start(out: Stream<T>): void {

--- a/src/extra/delay.ts
+++ b/src/extra/delay.ts
@@ -6,6 +6,7 @@ class DelayOperator<T> implements Operator<T, T> {
 
   constructor(public dt: number,
               public ins: Stream<T>) {
+    console.warn('All time based operators have been deprecated, please migrate to @cycle/time');
   }
 
   _start(out: Stream<T>): void {

--- a/src/extra/fromDiagram.ts
+++ b/src/extra/fromDiagram.ts
@@ -26,6 +26,8 @@ export class DiagramProducer implements InternalProducer<any> {
     this.timeUnit = (opt && opt.timeUnit) ? opt.timeUnit : 20;
     this.values = (opt && opt.values) ? opt.values : {};
     this.tasks = [];
+
+    console.warn('All time based operators have been deprecated, please migrate to @cycle/time');
   }
 
   _start(out: InternalListener<any>) {

--- a/src/extra/periodic.ts
+++ b/src/extra/periodic.ts
@@ -1,0 +1,48 @@
+import {InternalProducer, InternalListener, Stream} from '../index';
+
+class Periodic implements InternalProducer<number> {
+  public type = 'periodic';
+  public period: number;
+  private intervalID: any;
+  private i: number;
+
+  constructor(period: number) {
+    this.period = period;
+    this.intervalID = -1;
+    this.i = 0;
+
+    console.warn('All time based operators have been deprecated, please migrate to @cycle/time');
+  }
+
+  _start(out: InternalListener<number>): void {
+    const self = this;
+    function intervalHandler() { out._n(self.i++); }
+    this.intervalID = setInterval(intervalHandler, this.period);
+  }
+
+  _stop(): void {
+    if (this.intervalID !== -1) clearInterval(this.intervalID);
+    this.intervalID = -1;
+    this.i = 0;
+  }
+}
+
+/**
+   * Creates a stream that periodically emits incremental numbers, every
+   * `period` milliseconds.
+   *
+   * Marble diagram:
+   *
+   * ```text
+   *     periodic(1000)
+   * ---0---1---2---3---4---...
+   * ```
+   *
+   * @factory true
+   * @param {number} period The interval in milliseconds to use as a rate of
+   * emission.
+   * @return {Stream}
+   */
+export default function periodic(period: number): Stream<number> {
+  return new Stream<number>(new Periodic(period));
+}

--- a/src/extra/throttle.ts
+++ b/src/extra/throttle.ts
@@ -7,6 +7,7 @@ class ThrottleOperator<T> implements Operator<T, T> {
 
   constructor(public dt: number,
               public ins: Stream<T>) {
+    console.warn('All time based operators have been deprecated, please migrate to @cycle/time');
   }
 
   _start(out: Stream<T>): void {

--- a/src/extra/tween.ts
+++ b/src/extra/tween.ts
@@ -1,5 +1,6 @@
 import {Stream} from '../index';
 import concat from './concat';
+import periodic from './periodic';
 
 export type Ease = (x: number, from: number, to: number) => number;
 export type Easings = {
@@ -201,8 +202,10 @@ function tween({
   ease = tweenFactory.linear.ease,
   interval = DEFAULT_INTERVAL
 }: TweenConfig): Stream<number> {
+    console.warn('All time based operators have been deprecated, please migrate to @cycle/time');
+
   const totalTicks = Math.round(duration / interval);
-  return Stream.periodic(interval)
+  return periodic(interval)
     .take(totalTicks)
     .map(tick => ease(tick / totalTicks, from, to))
     .compose(s => concat<number>(s, Stream.of(to)));

--- a/src/index.ts
+++ b/src/index.ts
@@ -466,31 +466,6 @@ class FromPromise<T> implements InternalProducer<T> {
   }
 }
 
-class Periodic implements InternalProducer<number> {
-  public type = 'periodic';
-  public period: number;
-  private intervalID: any;
-  private i: number;
-
-  constructor(period: number) {
-    this.period = period;
-    this.intervalID = -1;
-    this.i = 0;
-  }
-
-  _start(out: InternalListener<number>): void {
-    const self = this;
-    function intervalHandler() { out._n(self.i++); }
-    this.intervalID = setInterval(intervalHandler, this.period);
-  }
-
-  _stop(): void {
-    if (this.intervalID !== -1) clearInterval(this.intervalID);
-    this.intervalID = -1;
-    this.i = 0;
-  }
-}
-
 class Debug<T> implements Operator<T, T> {
   public type = 'debug';
   public ins: Stream<T>;
@@ -1419,26 +1394,6 @@ export class Stream<T> implements InternalListener<T> {
   static fromObservable<T>(obs: {subscribe: any}): Stream<T> {
     if ((obs as Stream<T>).endWhen) return obs as Stream<T>;
     return new Stream<T>(new FromObservable(obs));
-  }
-
-  /**
-   * Creates a stream that periodically emits incremental numbers, every
-   * `period` milliseconds.
-   *
-   * Marble diagram:
-   *
-   * ```text
-   *     periodic(1000)
-   * ---0---1---2---3---4---...
-   * ```
-   *
-   * @factory true
-   * @param {number} period The interval in milliseconds to use as a rate of
-   * emission.
-   * @return {Stream}
-   */
-  static periodic(period: number): Stream<number> {
-    return new Stream<number>(new Periodic(period));
   }
 
   /**

--- a/tests/extra/buffer.ts
+++ b/tests/extra/buffer.ts
@@ -3,7 +3,10 @@
 import xs from '../../src/index';
 import buffer from '../../src/extra/buffer';
 import delay from '../../src/extra/delay';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('buffer (extra)', () => {
   it('should complete when separator is completed before the source', (done) => {
@@ -63,7 +66,7 @@ describe('buffer (extra)', () => {
   });
 
   it('should emit when separator is completed', (done) => {
-    const source = xs.periodic(20).take(5);
+    const source = periodic(20).take(5);
     const separator = xs.empty().compose(delay(150));
     const buffered = source.compose(buffer(separator));
     const expected = [[0, 1, 2, 3, 4]];
@@ -83,8 +86,8 @@ describe('buffer (extra)', () => {
   });
 
   it('should accumulate what source emits and emit when separator emits', (done) => {
-    const source = xs.periodic(100).take(10);
-    const separator = xs.periodic(350).take(3);
+    const source = periodic(100).take(10);
+    const separator = periodic(350).take(3);
     const buffered = source.compose(buffer(separator));
     const expected = [[0, 1, 2], [3, 4, 5], [6, 7, 8, 9]];
 
@@ -104,7 +107,7 @@ describe('buffer (extra)', () => {
 
   it('should not emit empty buffers', (done) => {
     const source = xs.of(1).compose(delay(100));
-    const separator = xs.periodic(20).take(5);
+    const separator = periodic(20).take(5);
     const buffered = source.compose(buffer(separator));
     const expected = [[1]];
 

--- a/tests/extra/concat.ts
+++ b/tests/extra/concat.ts
@@ -2,7 +2,10 @@
 /// <reference types="node" />
 import xs from '../../src/index';
 import concat from '../../src/extra/concat';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('concat (extra)', () => {
   it('should concatenate two synchronous short streams together', (done: any) => {
@@ -25,8 +28,8 @@ describe('concat (extra)', () => {
   });
 
   it('should concatenate two asynchronous short streams together', (done: any) => {
-    const stream1 = xs.periodic(50).take(3);
-    const stream2 = xs.periodic(100).take(2);
+    const stream1 = periodic(50).take(3);
+    const stream2 = periodic(100).take(2);
     const stream = concat(stream1, stream2);
     const expected = [0, 1, 2, 0, 1];
 
@@ -43,7 +46,7 @@ describe('concat (extra)', () => {
   });
 
   it('should append a synchronous stream after an asynchronous stream', (done: any) => {
-    const stream1 = xs.periodic(50).take(3);
+    const stream1 = periodic(50).take(3);
     const stream2 = xs.of(30, 40, 50, 60);
     const stream = concat(stream1, stream2);
     const expected = [0, 1, 2, 30, 40, 50, 60];

--- a/tests/extra/delay.ts
+++ b/tests/extra/delay.ts
@@ -2,11 +2,14 @@
 /// <reference types="node" />
 import xs from '../../src/index';
 import delay from '../../src/extra/delay';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('delay (extra)', () => {
   it('should delay periodic events by a given time period', (done: any) => {
-    const stream = xs.periodic(100).take(3).compose(delay(200));
+    const stream = periodic(100).take(3).compose(delay(200));
     const expected = [0, 1, 2];
     let completeCalled = false;
 

--- a/tests/extra/dropUntil.ts
+++ b/tests/extra/dropUntil.ts
@@ -2,13 +2,16 @@
 /// <reference types="node" />
 import xs from '../../src/index';
 import dropUntil from '../../src/extra/dropUntil';
+import periodic from '../../src/extra/periodic';
 import delay from '../../src/extra/delay';
 import * as assert from 'assert';
 
+console.warn = () => {};
+
 describe('dropUntil (extra)', () => {
   it('should start emitting the stream when another stream emits next', (done: any) => {
-    const source = xs.periodic(50).take(6);
-    const other = xs.periodic(220).take(1);
+    const source = periodic(50).take(6);
+    const other = periodic(220).take(1);
     const stream = source.compose(dropUntil(other));
     const expected = [4, 5];
 
@@ -25,7 +28,7 @@ describe('dropUntil (extra)', () => {
   });
 
   it('should complete the stream when another stream emits complete', (done: any) => {
-    const source = xs.periodic(50).take(6);
+    const source = periodic(50).take(6);
     const other = xs.empty().compose(delay(220));
     const stream = source.compose(dropUntil(other));
     const expected = [4, 5];

--- a/tests/extra/flattenConcurrently.ts
+++ b/tests/extra/flattenConcurrently.ts
@@ -2,12 +2,15 @@
 /// <reference types="node" />
 import xs, {Stream, Listener} from '../../src/index';
 import flattenConcurrently from '../../src/extra/flattenConcurrently';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('flattenConcurrently (extra)', () => {
   describe('with map', () => {
     it('should expand each periodic event with 3 sync events', (done: any) => {
-      const stream = xs.periodic(100).take(3)
+      const stream = periodic(100).take(3)
         .map(i => xs.of(1 + i, 2 + i, 3 + i))
         .compose(flattenConcurrently);
       const expected = [1, 2, 3, 2, 3, 4, 3, 4, 5];
@@ -43,7 +46,7 @@ describe('flattenConcurrently (extra)', () => {
 
     it('should expand 3 sync events as a periodic each', (done: any) => {
       const stream = xs.of(0, 1, 2)
-        .map(i => xs.periodic(100 * (i + 1) + 10 * i).take(2).map(x => `${i}${x}`))
+        .map(i => periodic(100 * (i + 1) + 10 * i).take(2).map(x => `${i}${x}`))
         .compose(flattenConcurrently);
       // ---x---x---x---x---x---x
       // ---00--01
@@ -64,9 +67,9 @@ describe('flattenConcurrently (extra)', () => {
     });
 
     it('should expand 3 async events as a periodic each', (done: any) => {
-      const stream = xs.periodic(140).take(3)
+      const stream = periodic(140).take(3)
         .map(i =>
-          xs.periodic(100 * (i < 2 ? 1 : i)).take(3).map(x => `${i}${x}`)
+          periodic(100 * (i < 2 ? 1 : i)).take(3).map(x => `${i}${x}`)
         )
         .compose(flattenConcurrently);
       // ---x---x---x---x---x---x---x---x---x---x---x---x
@@ -88,9 +91,9 @@ describe('flattenConcurrently (extra)', () => {
     });
 
     it('should expand 3 async events as a periodic each, no optimization', (done: any) => {
-      const stream = xs.periodic(140).take(3)
+      const stream = periodic(140).take(3)
         .map(i =>
-          xs.periodic(100 * (i < 2 ? 1 : i)).take(3).map(x => `${i}${x}`)
+          periodic(100 * (i < 2 ? 1 : i)).take(3).map(x => `${i}${x}`)
         )
         .filter(() => true) // breaks the optimization map+flattenConcurrently
         .compose(flattenConcurrently);
@@ -114,7 +117,7 @@ describe('flattenConcurrently (extra)', () => {
     });
 
     it('should propagate user mistakes in project as errors', (done: any) => {
-      const source = xs.periodic(30).take(1);
+      const source = periodic(30).take(1);
       const stream = source.map(
         x => {
           const y = (<string> <any> x).toLowerCase();
@@ -140,14 +143,14 @@ describe('flattenConcurrently (extra)', () => {
       let predicateCallCount = 0;
       let projectCallCount = 0;
 
-      const stream = xs.periodic(140).take(3)
+      const stream = periodic(140).take(3)
         .filter(i => {
           predicateCallCount += 1;
           return i % 2 === 0;
         })
         .map(i => {
           projectCallCount += 1;
-          return xs.periodic(100 * (i < 2 ? 1 : i)).take(3).map(x => `${i}${x}`);
+          return periodic(100 * (i < 2 ? 1 : i)).take(3).map(x => `${i}${x}`);
         })
         .compose(flattenConcurrently);
       // ---x---x---x---x---x---x---x---x---x---x---x---x

--- a/tests/extra/flattenSequentially.ts
+++ b/tests/extra/flattenSequentially.ts
@@ -2,12 +2,15 @@
 /// <reference types="node" />
 import xs from '../../src/index';
 import flattenSequentially from '../../src/extra/flattenSequentially';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('flattenSequentially (extra)', () => {
   describe('with map', () => {
     it('should expand each periodic event with 3 sync events', (done: any) => {
-      const stream = xs.periodic(100).take(3)
+      const stream = periodic(100).take(3)
         .map(i => xs.of(1 + i, 2 + i, 3 + i))
         .compose(flattenSequentially);
       const expected = [1, 2, 3, 2, 3, 4, 3, 4, 5];
@@ -26,7 +29,7 @@ describe('flattenSequentially (extra)', () => {
 
     it('should expand each sync event as a periodic stream and concatenate', (done: any) => {
       const stream = xs.of(1, 2, 3)
-        .map(i => xs.periodic(100).take(3).map(x => `${i}${x}`))
+        .map(i => periodic(100).take(3).map(x => `${i}${x}`))
         .compose(flattenSequentially);
       const expected = ['10', '11', '12', '20', '21', '22', '30', '31', '32'];
       const listener = {
@@ -44,7 +47,7 @@ describe('flattenSequentially (extra)', () => {
 
     it('should expand 3 sync events as a periodic each', (done: any) => {
       const stream = xs.of(1, 2, 3)
-        .map(i => xs.periodic(100 * i).take(2).map(x => `${i}${x}`))
+        .map(i => periodic(100 * i).take(2).map(x => `${i}${x}`))
         .compose(flattenSequentially);
       // ---x---x---x---x---x---x
       // ---10--11
@@ -65,9 +68,9 @@ describe('flattenSequentially (extra)', () => {
     });
 
     it('should expand 3 async events as a periodic each', (done: any) => {
-      const stream = xs.periodic(140).take(3)
+      const stream = periodic(140).take(3)
         .map(i =>
-          xs.periodic(100 * (i < 2 ? 1 : i)).take(3).map(x => `${i}${x}`)
+          periodic(100 * (i < 2 ? 1 : i)).take(3).map(x => `${i}${x}`)
         )
         .compose(flattenSequentially);
       // ---x---x---x---x---x---x---x---x---x---x---x---x
@@ -88,9 +91,9 @@ describe('flattenSequentially (extra)', () => {
     });
 
     it('should expand 3 async events as a periodic each, no optimization', (done: any) => {
-      const stream = xs.periodic(140).take(3)
+      const stream = periodic(140).take(3)
         .map(i =>
-          xs.periodic(100 * (i < 2 ? 1 : i)).take(3).map(x => `${i}${x}`)
+          periodic(100 * (i < 2 ? 1 : i)).take(3).map(x => `${i}${x}`)
         )
         .filter(() => true) // breaks an optimization map+flattenSequentially
         .compose(flattenSequentially);
@@ -114,7 +117,7 @@ describe('flattenSequentially (extra)', () => {
     });
 
     it('should propagate user mistakes in project as errors', (done: any) => {
-      const source = xs.periodic(30).take(1);
+      const source = periodic(30).take(1);
       const stream = source.map(
         x => {
           const y = (<string> <any> x).toLowerCase();
@@ -136,7 +139,7 @@ describe('flattenSequentially (extra)', () => {
 
     it('should emit data from inner streams after synchronous outer completes', (done: any) => {
       const outer = xs.of(42);
-      const stream = outer.map(i => xs.periodic(50).take(2).mapTo(i))
+      const stream = outer.map(i => periodic(50).take(2).mapTo(i))
         .compose(flattenSequentially);
       const expected = [42, 42];
 
@@ -157,7 +160,7 @@ describe('flattenSequentially (extra)', () => {
 
       const stream = xs.of(1)
         .map(i =>
-          xs.periodic(150).take(3) // 150ms, 300ms, 450ms, 600ms
+          periodic(150).take(3) // 150ms, 300ms, 450ms, 600ms
             .debug(x => assert.strictEqual(x, expectedInner.shift()))
         )
         .compose(flattenSequentially);

--- a/tests/extra/sampleCombine.ts
+++ b/tests/extra/sampleCombine.ts
@@ -2,12 +2,15 @@
 /// <reference types="node" />
 import xs, { Stream } from '../../src/index';
 import sampleCombine from '../../src/extra/sampleCombine';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('sampleCombine (extra)', () => {
   it('should combine AND-style two streams together', (done: any) => {
-    const stream1 = xs.periodic(100).take(3).startWith(-1);
-    const stream2 = xs.periodic(99).take(3);
+    const stream1 = periodic(100).take(3).startWith(-1);
+    const stream2 = periodic(99).take(3);
     const stream = stream1.compose(sampleCombine(stream2));
     let expected = [[0, 0], [1, 1], [2, 2]];
     stream.addListener({
@@ -45,8 +48,8 @@ describe('sampleCombine (extra)', () => {
   });
 
   it('should complete only when the sample stream has completed', (done: any) => {
-    const stream1 = xs.periodic(100).take(4);
-    const stream2 = xs.periodic(99).take(1);
+    const stream1 = periodic(100).take(4);
+    const stream2 = periodic(99).take(1);
     const stream = stream1.compose(sampleCombine(stream2)).map(arr => arr.join(''));
     let expected = ['00', '10', '20', '30'];
     stream.addListener({
@@ -62,8 +65,8 @@ describe('sampleCombine (extra)', () => {
   });
 
   it('should not pick values from sampled streams before they have emitted', (done: any) => {
-    const stream1 = xs.periodic(100).take(4);
-    const stream2 = xs.periodic(150).take(1);
+    const stream1 = periodic(100).take(4);
+    const stream2 = periodic(150).take(1);
     const stream = stream1.compose(sampleCombine(stream2)).map(arr => arr.join(''));
     let expected = ['10', '20', '30'];
     stream.addListener({
@@ -79,7 +82,7 @@ describe('sampleCombine (extra)', () => {
   });
 
   it('should just wrap the value if combining one stream', (done: any) => {
-    const source = xs.periodic(100).take(3);
+    const source = periodic(100).take(3);
     const stream = source.compose(sampleCombine());
     let expected = [[0], [1], [2]];
 
@@ -158,16 +161,16 @@ describe('sampleCombine (extra)', () => {
   });
 
   it('should return a Stream when combining a MemoryStream with a Stream', (done: any) => {
-    const input1 = xs.periodic(80).take(4).remember();
-    const input2 = xs.periodic(50).take(3);
+    const input1 = periodic(80).take(4).remember();
+    const input2 = periodic(50).take(3);
     const stream: Stream<[number, number]> = input1.compose(sampleCombine(input2));
     assert.strictEqual(stream instanceof Stream, true);
     done();
   });
 
   it('should return a Stream when combining a MemoryStream with a MemoryStream', (done: any) => {
-    const input1 = xs.periodic(80).take(4).remember();
-    const input2 = xs.periodic(50).take(3).remember();
+    const input1 = periodic(80).take(4).remember();
+    const input2 = periodic(50).take(3).remember();
     const stream: Stream<[number, number]> = input1.compose(sampleCombine(input2));
     assert.strictEqual(stream instanceof Stream, true);
     done();

--- a/tests/extra/split.ts
+++ b/tests/extra/split.ts
@@ -3,12 +3,15 @@
 import xs, { Stream } from '../../src/index';
 import split from '../../src/extra/split';
 import concat from '../../src/extra/concat';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('split (extra)', () => {
   it('should split a stream using a separator stream', (done: any) => {
-    const source = xs.periodic(50).take(10);
-    const separator = concat(xs.periodic(167).take(2), xs.never());
+    const source = periodic(50).take(10);
+    const separator = concat(periodic(167).take(2), xs.never());
     const stream = source.compose(split(separator));
     const outerExpected = [
       [0, 1, 2],
@@ -46,8 +49,8 @@ describe('split (extra)', () => {
   });
 
   it('should be canceled out if flattened immediately after', (done: any) => {
-    const source = xs.periodic(50).take(10);
-    const separator = concat(xs.periodic(167).take(2), xs.never());
+    const source = periodic(50).take(10);
+    const separator = concat(periodic(167).take(2), xs.never());
     const stream = source.compose(split(separator)).flatten();
     const expected = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
@@ -64,8 +67,8 @@ describe('split (extra)', () => {
   });
 
   it('should complete when the separator completes', (done: any) => {
-    const source = xs.periodic(50).take(10);
-    const separator = xs.periodic(167).take(2);
+    const source = periodic(50).take(10);
+    const separator = periodic(167).take(2);
     const stream = source.compose(split(separator)).flatten();
     const expected = [0, 1, 2, 3, 4, 5];
 

--- a/tests/factory/combine.ts
+++ b/tests/factory/combine.ts
@@ -1,12 +1,13 @@
 /// <reference types="mocha"/>
 /// <reference types="node" />
 import xs, {Stream} from '../../src/index';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
 
 describe('xs.combine', () => {
   it('should combine AND-style two streams together', (done: any) => {
-    const stream1 = xs.periodic(100).take(2);
-    const stream2 = xs.periodic(120).take(2);
+    const stream1 = periodic(100).take(2);
+    const stream2 = periodic(120).take(2);
     const stream = xs.combine(stream1, stream2);
     let expected = [[0,0], [1,0], [1,1]];
     stream.addListener({
@@ -28,8 +29,8 @@ describe('xs.combine', () => {
   });
 
   it('should return new Array not reusing instance for each emission', (done: any) => {
-    const stream1 = xs.periodic(100).take(2);
-    const stream2 = xs.periodic(120).take(2);
+    const stream1 = periodic(100).take(2);
+    const stream2 = periodic(120).take(2);
     const stream = xs.combine(stream1, stream2);
     let expected = [0,0];
     let last: any = undefined;
@@ -64,8 +65,8 @@ describe('xs.combine', () => {
   });
 
   it('should complete only when all member streams have completed', (done: any) => {
-    const stream1 = xs.periodic(30).take(1);
-    const stream2 = xs.periodic(50).take(4);
+    const stream1 = periodic(30).take(1);
+    const stream2 = periodic(50).take(4);
     const stream = xs.combine(stream1, stream2).map(arr => arr.join(''))
     let expected = ['00', '01', '02', '03'];
     stream.addListener({
@@ -96,7 +97,7 @@ describe('xs.combine', () => {
   });
 
   it('should just wrap the value if combining one stream', (done: any) => {
-    const source = xs.periodic(100).take(3);
+    const source = periodic(100).take(3);
     const stream = xs.combine(source);
     let expected = [[0], [1], [2]];
 
@@ -172,16 +173,16 @@ describe('xs.combine', () => {
   });
 
   it('should return a Stream when combining a MemoryStream with a Stream', (done: any) => {
-    const input1 = xs.periodic(50).take(4).remember();
-    const input2 = xs.periodic(80).take(3);
+    const input1 = periodic(50).take(4).remember();
+    const input2 = periodic(80).take(3);
     const stream: Stream<[number, number]> = xs.combine(input1, input2);
     assert.strictEqual(stream instanceof Stream, true);
     done();
   });
 
   it('should return a Stream when combining a MemoryStream with a MemoryStream', (done: any) => {
-    const input1 = xs.periodic(50).take(4).remember();
-    const input2 = xs.periodic(80).take(3).remember();
+    const input1 = periodic(50).take(4).remember();
+    const input2 = periodic(80).take(3).remember();
     const stream: Stream<[number, number]> = xs.combine(input1, input2);
     assert.strictEqual(stream instanceof Stream, true);
     done();

--- a/tests/factory/merge.ts
+++ b/tests/factory/merge.ts
@@ -1,13 +1,16 @@
 /// <reference types="mocha"/>
 /// <reference types="node" />
 import xs, {Stream} from '../../src/index';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('xs.merge', () => {
   it('should merge OR-style two streams together', (done: any) => {
     const stream = xs.merge(
-      xs.periodic(100).take(2),
-      xs.periodic(120).take(2)
+      periodic(100).take(2),
+      periodic(120).take(2)
     );
     let expected = [0, 0, 1, 1];
     stream.addListener({
@@ -23,8 +26,8 @@ describe('xs.merge', () => {
   });
 
   it('should complete only when all member streams have completed', (done: any) => {
-    const stream1 = xs.periodic(30).take(1);
-    const stream2 = xs.periodic(50).take(4);
+    const stream1 = periodic(30).take(1);
+    const stream2 = periodic(50).take(4);
     const stream = xs.merge(stream1, stream2);
     let expected = [0, 0, 1, 2, 3];
     stream.addListener({
@@ -60,16 +63,16 @@ describe('xs.merge', () => {
   });
 
   it('should return a Stream when merging a MemoryStream with a Stream', (done: any) => {
-    const input1 = xs.periodic(50).take(4).remember();
-    const input2 = xs.periodic(80).take(3);
+    const input1 = periodic(50).take(4).remember();
+    const input2 = periodic(80).take(3);
     const stream: Stream<number> = xs.merge(input1, input2);
     assert.strictEqual(stream instanceof Stream, true);
     done();
   });
 
   it('should return a Stream when merging a MemoryStream with a MemoryStream', (done: any) => {
-    const input1 = xs.periodic(50).take(4).remember();
-    const input2 = xs.periodic(80).take(3).remember();
+    const input1 = periodic(50).take(4).remember();
+    const input2 = periodic(80).take(3).remember();
     const stream: Stream<number> = xs.merge(input1, input2);
     assert.strictEqual(stream instanceof Stream, true);
     done();

--- a/tests/memoryStream.ts
+++ b/tests/memoryStream.ts
@@ -2,6 +2,9 @@
 /// <reference types="node"/>
 import xs, {Listener} from '../src/index';
 import * as assert from 'assert';
+import periodic from '../src/extra/periodic';
+
+console.warn = () => {};
 
 describe('MemoryStream', () => {
   it('should allow use like a subject, from xs.createWithMemory()', (done: any) => {
@@ -134,7 +137,7 @@ describe('MemoryStream', () => {
   });
 
   it('should teardown upstream MemoryStream memory on late async stop', (done: any) => {
-    const stream = xs.periodic(500).mapTo('world').startWith('hello').take(2);
+    const stream = periodic(500).mapTo('world').startWith('hello').take(2);
     const expected1 = ['hello', 'world'];
 
     function addSecondListener() {
@@ -172,7 +175,7 @@ describe('MemoryStream', () => {
   it('should not allow an operator listener to be indefinitely attached', (done: any) => {
     let debugCalled = 0;
     const debugExpected = [42, 0];
-    const source$ = xs.periodic(100).startWith(42)
+    const source$ = periodic(100).startWith(42)
       .debug(x => {
         debugCalled += 1;
         assert.strictEqual(debugExpected.length > 0, true);

--- a/tests/operator/debug.ts
+++ b/tests/operator/debug.ts
@@ -1,8 +1,11 @@
 /// <reference types="mocha"/>
 /// <reference types="node" />
 import xs, {Stream, MemoryStream} from '../../src/index';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
 import * as sinon from 'sinon';
+
+console.warn = () => {};
 
 var sandbox: sinon.SinonSandbox;
 describe('Stream.prototype.debug', () => {
@@ -16,7 +19,7 @@ describe('Stream.prototype.debug', () => {
 
   it('should allow inspecting the operator chain', (done: any) => {
     const expected = [0, 1, 2];
-    const stream = xs.periodic(50).take(3).debug(x => {
+    const stream = periodic(50).take(3).debug(x => {
       assert.equal(x, expected.shift());
     });
     let listener = {
@@ -37,7 +40,7 @@ describe('Stream.prototype.debug', () => {
     let stub = sandbox.stub(console, 'log');
 
     const expected = [0, 1, 2];
-    const stream = xs.periodic(50).take(3).debug();
+    const stream = periodic(50).take(3).debug();
 
     assert.doesNotThrow(() => {
       stream.addListener({
@@ -73,7 +76,7 @@ describe('Stream.prototype.debug', () => {
   });
 
   it('should propagate user mistakes in spy as errors', (done: any) => {
-    const source = xs.periodic(30).take(1);
+    const source = periodic(30).take(1);
     const stream = source.debug(
       x => <number> <any> (<string> <any> x).toLowerCase()
     );

--- a/tests/operator/drop.ts
+++ b/tests/operator/drop.ts
@@ -1,11 +1,14 @@
 /// <reference types="mocha"/>
 /// <reference types="node" />
 import xs, {Stream, MemoryStream} from '../../src/index';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('Stream.prototype.drop', () => {
   it('should allow specifying max amount to drop from input stream', (done: any) => {
-    const stream = xs.periodic(50).drop(4);
+    const stream = periodic(50).drop(4);
     const expected = [4, 5, 6];
     let listener = {
       next: (x: number) => {

--- a/tests/operator/endWhen.ts
+++ b/tests/operator/endWhen.ts
@@ -2,12 +2,15 @@
 /// <reference types="node" />
 import xs, {Stream, MemoryStream} from '../../src/index';
 import delay from '../../src/extra/delay';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('Stream.prototype.endWhen', () => {
   it('should complete the stream when another stream emits next', (done: any) => {
-    const source = xs.periodic(50);
-    const other = xs.periodic(220).take(1);
+    const source = periodic(50);
+    const other = periodic(220).take(1);
     const stream = source.endWhen(other);
     const expected = [0, 1, 2, 3];
 
@@ -24,7 +27,7 @@ describe('Stream.prototype.endWhen', () => {
   });
 
   it('should complete the stream when another stream emits complete', (done: any) => {
-    const source = xs.periodic(50);
+    const source = periodic(50);
     const other = xs.empty().compose(delay(220));
     const stream = source.endWhen(other);
     const expected = [0, 1, 2, 3];

--- a/tests/operator/filter.ts
+++ b/tests/operator/filter.ts
@@ -1,11 +1,14 @@
 /// <reference types="mocha"/>
 /// <reference types="node" />
 import xs, {Stream, MemoryStream} from '../../src/index';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('Stream.prototype.filter', () => {
   it('should filter in only even numbers from an input stream', (done: any) => {
-    const stream = xs.periodic(50).filter(i => i % 2 === 0);
+    const stream = periodic(50).filter(i => i % 2 === 0);
     const expected = [0, 2, 4, 6];
     let listener = {
       next: (x: number) => {
@@ -22,7 +25,7 @@ describe('Stream.prototype.filter', () => {
   });
 
   it('should propagate user mistakes in predicate as errors', (done: any) => {
-    const source = xs.periodic(30).take(1);
+    const source = periodic(30).take(1);
     const stream = source.filter(
       x => (<string> <any> x).toLowerCase() === 'a'
     );

--- a/tests/operator/fold.ts
+++ b/tests/operator/fold.ts
@@ -1,11 +1,14 @@
 /// <reference types="mocha"/>
 /// <reference types="node" />
 import xs, {Stream, MemoryStream} from '../../src/index';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('Stream.prototype.fold', () => {
   it('should accumulating a value over time', (done: any) => {
-    const stream = xs.periodic(50).take(4).fold((x: number, y: number) => x + y, 0);
+    const stream = periodic(50).take(4).fold((x: number, y: number) => x + y, 0);
     const expected = [0, 0, 1, 3, 6];
     let listener = {
       next: (x: number) => {
@@ -22,7 +25,7 @@ describe('Stream.prototype.fold', () => {
   });
 
   it('should propagate user mistakes in accumulate as errors', (done: any) => {
-    const source = xs.periodic(30).take(1);
+    const source = periodic(30).take(1);
     const stream = source.fold(
       (x, y) => <number> <any> (<string> <any> x).toLowerCase(),
       0

--- a/tests/operator/imitate.ts
+++ b/tests/operator/imitate.ts
@@ -2,7 +2,10 @@
 /// <reference types="node" />
 import xs, {Producer, Listener, Stream, MemoryStream} from '../../src/index';
 import delay from '../../src/extra/delay';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('Stream.prototype.imitate', () => {
   it('should be able to model a circular dependency in the stream graph', (done: any) => {
@@ -157,7 +160,7 @@ describe('Stream.prototype.imitate', () => {
   });
 
   it('should not cause stack overflow while detecting cycles', (done: any) => {
-    const outside = xs.periodic(150);
+    const outside = periodic(150);
     const secondMimic = xs.create<number>();
     const first = xs.merge(outside, secondMimic.map(x => x * 10));
     const second = first.map(x => x + 1).compose(delay(100));
@@ -244,7 +247,7 @@ describe('Stream.prototype.imitate', () => {
 
   it('should not by itself start the target stream execution', (done: any) => {
     let nextDelivered = false;
-    const stream = xs.periodic(50).take(3).debug(() => {
+    const stream = periodic(50).take(3).debug(() => {
       nextDelivered = true;
     });
     const proxyStream = xs.create<number>();
@@ -258,7 +261,7 @@ describe('Stream.prototype.imitate', () => {
   });
 
   it('should throw an error when given a MemoryStream', (done: any) => {
-    const stream = xs.periodic(50).take(3).remember();
+    const stream = periodic(50).take(3).remember();
     assert.strictEqual(stream instanceof MemoryStream, true);
     const proxyStream = xs.create<number>();
     assert.throws(() => {
@@ -282,6 +285,6 @@ describe('Stream.prototype.imitate', () => {
       },
     });
 
-    mimic.imitate(xs.periodic(50).take(3));
+    mimic.imitate(periodic(50).take(3));
   });
 });

--- a/tests/operator/map.ts
+++ b/tests/operator/map.ts
@@ -1,11 +1,14 @@
 /// <reference types="mocha"/>
 /// <reference types="node" />
 import xs, {Stream, MemoryStream} from '../../src/index';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('Stream.prototype.map', () => {
   it('should transform values from input stream to output stream', (done: any) => {
-    const stream = xs.periodic(100).map(i => 10 * i).take(3);
+    const stream = periodic(100).map(i => 10 * i).take(3);
     const expected = [0, 10, 20];
 
     stream.addListener({
@@ -21,7 +24,7 @@ describe('Stream.prototype.map', () => {
   });
 
   it('should propagate user mistakes in project as errors', (done: any) => {
-    const source = xs.periodic(30).take(1);
+    const source = periodic(30).take(1);
     const stream = source.map(
       x => (<string> <any> x).toLowerCase()
     );

--- a/tests/operator/mapTo.ts
+++ b/tests/operator/mapTo.ts
@@ -1,11 +1,14 @@
 /// <reference types="mocha"/>
 /// <reference types="node" />
 import xs, {Stream, MemoryStream} from '../../src/index';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('Stream.prototype.mapTo', () => {
   it('should transform events to a constant value', (done: any) => {
-    const stream = xs.periodic(100).mapTo(10);
+    const stream = periodic(100).mapTo(10);
     const expected = [10, 10, 10];
     let listener = {
       next: (x: number) => {
@@ -38,7 +41,7 @@ describe('Stream.prototype.mapTo', () => {
   });
 
   it('should have \'type\' metadata on the operator producer', (done: any) => {
-    const stream = xs.periodic(100).mapTo(10);
+    const stream = periodic(100).mapTo(10);
     assert.strictEqual(stream['_prod']['type'], 'mapTo');
     done();
   });

--- a/tests/operator/remember.ts
+++ b/tests/operator/remember.ts
@@ -1,12 +1,15 @@
 /// <reference types="mocha"/>
 /// <reference types="node" />
 import xs, {Stream, MemoryStream} from '../../src/index';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
 function noop() {};
 
+console.warn = () => {};
+
 describe('Stream.prototype.remember', () => {
   it('should replay the second event to a new listener', (done: any) => {
-    const stream = xs.periodic(50).take(4).remember();
+    const stream = periodic(50).take(4).remember();
 
     stream.addListener({next: noop, error: noop, complete: noop});
 
@@ -29,7 +32,7 @@ describe('Stream.prototype.remember', () => {
     let expectedA = [10];
     let expectedB = [10];
 
-    const source = xs.never().endWhen(xs.periodic(300))
+    const source = xs.never().endWhen(periodic(300))
       .fold((acc, x) => acc + x, 10)
       .map(x => x)
       .remember();

--- a/tests/operator/take.ts
+++ b/tests/operator/take.ts
@@ -1,11 +1,14 @@
 /// <reference types="mocha"/>
 /// <reference types="node" />
 import xs, {Stream, MemoryStream} from '../../src/index';
+import periodic from '../../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('Stream.prototype.take', () => {
   it('should allow specifying max amount to take from input stream', (done: any) => {
-    const stream = xs.periodic(50).take(4);
+    const stream = periodic(50).take(4);
     const expected = [0, 1, 2, 3];
     let listener = {
       next: (x: number) => {
@@ -38,7 +41,7 @@ describe('Stream.prototype.take', () => {
   });
 
   it('should not break sibling listeners when TakeOperator tears down', (done: any) => {
-    const source = xs.periodic(50);
+    const source = periodic(50);
     const streamA = source.take(3);
     const streamB = source.take(6);
     const expectedA = [0, 1, 2];
@@ -67,7 +70,7 @@ describe('Stream.prototype.take', () => {
   });
 
   it('should just complete if given max=0', (done: any) => {
-    const stream = xs.periodic(50).take(0);
+    const stream = periodic(50).take(0);
 
     stream.addListener({
       next: (x: number) => {

--- a/tests/stream.ts
+++ b/tests/stream.ts
@@ -2,7 +2,10 @@
 /// <reference types="node"/>
 import xs, {Producer, Listener, Stream} from '../src/index';
 import fromDiagram from '../src/extra/fromDiagram';
+import periodic from '../src/extra/periodic';
 import * as assert from 'assert';
+
+console.warn = () => {};
 
 describe('Stream', () => {
   it('should have all the core static operators', () => {
@@ -16,7 +19,6 @@ describe('Stream', () => {
     assert.equal(typeof xs.fromArray, 'function');
     assert.equal(typeof xs.fromPromise, 'function');
     assert.equal(typeof xs.fromObservable, 'function');
-    assert.equal(typeof xs.periodic, 'function');
     assert.equal(typeof xs.merge, 'function');
     assert.equal(typeof xs.combine, 'function');
   });
@@ -101,7 +103,7 @@ describe('Stream', () => {
   });
 
   it('should be possible to addListener and removeListener with 1 listener', (done: any) => {
-    const stream = xs.periodic(100);
+    const stream = periodic(100);
     const expected = [0, 1, 2];
     let listener = {
       next: (x: number) => {
@@ -118,7 +120,7 @@ describe('Stream', () => {
   });
 
   it('should broadcast events to two listeners', (done: any) => {
-    const stream = xs.periodic(100);
+    const stream = periodic(100);
     const expected1 = [0, 1, 2];
     const expected2 = [1, 2];
 
@@ -152,7 +154,7 @@ describe('Stream', () => {
   });
 
   it('should not stop if listener is synchronously removed and re-added', (done: any) => {
-    const stream = xs.periodic(100);
+    const stream = periodic(100);
     const expected = [0, 1, 2];
     let listener = {
       next: (x: number) => {
@@ -174,7 +176,7 @@ describe('Stream', () => {
   });
 
   it('should restart if listener is asynchronously removed and re-added', (done: any) => {
-    const stream = xs.periodic(100);
+    const stream = periodic(100);
     let expected = [0, 1, 2];
     let listener = {
       next: (x: number) => {
@@ -329,7 +331,7 @@ describe('Stream', () => {
     });
 
     it('should spy an existing stream execution', (done: any) => {
-      const stream = xs.periodic(200).take(8);
+      const stream = periodic(200).take(8);
       const listener = { next: () => { }, error: () => { }, complete: () => { } };
       const expected = [0, 1, 2];
 


### PR DESCRIPTION
Move xs.periodic to the extra operators, add a deprecation warning to all time based operators

periodic is no longer part of the `Stream` prototype

continuation of #216