### PR TITLE
TypeScript@2.6.1 with strictFunctionTypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "ts-node": "3.3.x",
     "tsify": "3.0.x",
     "tslint": "5.7.0",
-    "typescript": "2.5.2",
+    "typescript": "2.6.1",
     "validate-commit-msg": "2.4.x"
   },
   "publishConfig": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
+    "strictFunctionTypes": true,
     "suppressImplicitAnyIndexErrors": true,
     "module": "commonjs",
     "noEmitHelpers": false,


### PR DESCRIPTION
Sorry, this is not a fix. I wasn't sure how prepared I am to tackle an issue of this scope.

Short story is that I don't feel prepared.

So here it is, just a failing config.

My motivation is that it seems that `strictFunctionTypes` requires all dependent code to comply.
And that `strictFunctionTypes: true` is implied by `strict: true`, in v2.6.1.

Now, I don't know the benefits of `strictFunctionTypes`, but I suppose it is encouraged.