### PR TITLE
Lock symbol-observable to 1.0.4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/staltz/xstream#readme",
   "dependencies": {
-    "symbol-observable": "^1.0.4"
+    "symbol-observable": "1.0.4"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.40",


### PR DESCRIPTION
Next version up is 1.1.0 which causes tsc to fail compilation with
error TS2451: Cannot redeclare block-scoped variable 'Symbol'.

Appears to be related to benlesh/symbol-observable#34