### PR TITLE
chore(symbol-observable): update to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "homepage": "https://github.com/staltz/xstream#readme",
   "dependencies": {
-    "symbol-observable": "1.0.4"
+    "symbol-observable": "1.2.0"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.40",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3232,9 +3232,9 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
-symbol-observable@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+symbol-observable@1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 symbol-observable@^1.0.2:
   version "1.1.0"


### PR DESCRIPTION
just updating to the latest symbol-observable now that https://github.com/benlesh/symbol-observable/issues/34 is resolved.