### PR TITLE
Use export default xs to enable autoimport in VSCode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2049,4 +2049,5 @@ export class MemoryStream<T> extends Stream<T> {
 }
 
 export {NO, NO_IL};
-export default Stream;
+const xs = Stream
+export default xs;


### PR DESCRIPTION
![vscode-xs-import-demo](https://user-images.githubusercontent.com/6770225/38467352-b613e9ba-3b3f-11e8-82be-53389c03954e.gif)
