### PR TITLE
use Symbol.observable to get observable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1418,7 +1418,8 @@ export class Stream<T> implements InternalListener<T> {
    */
   static fromObservable<T>(obs: {subscribe: any}): Stream<T> {
     if ((obs as Stream<T>).endWhen) return obs as Stream<T>;
-    return new Stream<T>(new FromObservable(obs));
+    const o = typeof obs[$$observable] === 'function' ? obs[$$observable]() : obs;
+    return new Stream<T>(new FromObservable(o));
   }
 
   /**


### PR DESCRIPTION
In fromObservable, use Symbol.observable if present to get observable. If not present,treat received
object as a subscribable (current behaviour).

Some observables passed to `xs.fromObservable` might not have a `subscribe` method. It is also an issue for packages like `redux` or `router5` which have / might have a `subscribe` method with a different interface than observables (accepting listener functions rather than objects).

Note that `xs.fromObservable` accepts subscribables, but `xs.from` doesn't.