### PR TITLE
Use https in the website resources

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@ description: > # this means to ignore newlines until "baseurl:"
   line in _config.yml. It will appear in your document head meta (for
   Google search results) and in your feed.xml site description.
 baseurl: "" # the subpath of your site, e.g. /blog
-url: "http://staltz.com/xstream" # the base hostname & protocol for your site
+url: "https://staltz.com/xstream" # the base hostname & protocol for your site
 
 excerpt_separator: "\n\n\n"
 # Build settings


### PR DESCRIPTION
Chrome won't load the stylesheet because it refers to an non-secure resource