### PR TITLE
Use xstream from npm in website

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,7 +2,7 @@
   <div class="wrapper">
   </div>
 </footer>
-<script src="//raw.githubusercontent.com/staltz/xstream/master/dist/xstream.min.js"></script>
+<script src="https://unpkg.com/xstream/dist/xstream.min.js"></script>
 <script>
   window.xs = xstream.default;
   //<![CDATA[


### PR DESCRIPTION
GitHub doesn't serve the xstream file with a correct mimetype, so it wouldn't load.
Loading from unpkg.com solves that, and it loads the files from the npm package so it will be kept up-to-date.