### PR TITLE
fix(types): do not use arrow syntax for _start

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ const NO_IL: InternalListener<any> = {
 };
 
 export interface InternalProducer<T> {
-  _start: (listener: InternalListener<T>) => void;
+  _start(listener: InternalListener<T>): void;
   _stop: () => void;
 }
 
@@ -53,13 +53,13 @@ export interface OutSender<T> {
 export interface Operator<T, R> extends InternalProducer<R>, InternalListener<T>, OutSender<R> {
   type: string;
   ins: Stream<T>;
-  _start: (out: Stream<R>) => void;
+  _start(out: Stream<R>): void;
 }
 
 export interface Aggregator<T, U> extends InternalProducer<U>, OutSender<U> {
   type: string;
   insArr: Array<Stream<T>>;
-  _start: (out: Stream<U>) => void;
+  _start(out: Stream<U>): void;
 }
 
 export interface Producer<T> {


### PR DESCRIPTION
using arrow syntax for those methods which will
 be overridden by interface extention sometimes
 cause compile error. Fix by stop using arrow syntax

When I tried to use xstream in my library, it caused error like this
```
../../node_modules/xstream/index.d.ts:15:18 - error TS2430: Interface 'Operator<T, R>' incorrectly extends interface 'InternalProducer<R>'.
  Types of property '_start' are incompatible.
    Type '(out: Stream<R>) => void' is not assignable to type '(listener: InternalListener<R>) => void'.
      Types of parameters 'out' and 'listener' are incompatible.
        Type 'InternalListener<R>' is not assignable to type 'Stream<R>'.
          Property '_prod' is missing in type 'InternalListener<R>'.

15 export interface Operator<T, R> extends InternalProducer<R>, InternalListener<T>, OutSender<R> {
                    ~~~~~~~~


../../node_modules/xstream/index.d.ts:20:18 - error TS2430: Interface 'Aggregator<T, U>' incorrectly extends interface 'InternalProducer<U>'.
  Types of property '_start' are incompatible.
    Type '(out: Stream<U>) => void' is not assignable to type '(listener: InternalListener<U>) => void'.
      Types of parameters 'out' and 'listener' are incompatible.
        Type 'InternalListener<U>' is not assignable to type 'Stream<U>'.

20 export interface Aggregator<T, U> extends InternalProducer<U>, OutSender<U> {
```
This is because interface extension have different behavior when using arrow syntax or not. 
- refs: https://github.com/Microsoft/TypeScript/issues/4462

Actually, it is weird that xstream itself do not cause compile error when I run `yarn compile` . But anyway, This change allowed me to avoid compile error in my library.
