### PR TITLE
fix(dropUntil): align with rxjs skipUntil

### DIFF
--- a/src/extra/dropUntil.ts
+++ b/src/extra/dropUntil.ts
@@ -13,9 +13,7 @@ class OtherIL<T> implements InternalListener<any>, OutSender<T> {
     this.out._e(err);
   }
 
-  _c() {
-    this.op.up();
-  }
+  _c() {}
 }
 
 export class DropUntilOperator<T> implements Operator<T, T> {
@@ -63,14 +61,14 @@ export class DropUntilOperator<T> implements Operator<T, T> {
   _c() {
     const u = this.out;
     if (!u) return;
-    this.up();
+    this._stop();
     u._c();
   }
 }
 
 /**
  * Starts emitting the input stream when another stream emits a next event. The
- * output stream will complete if/when the other stream completes.
+ * output stream will emit no items if another stream is empty.
  *
  * Marble diagram:
  *
@@ -106,8 +104,8 @@ export class DropUntilOperator<T> implements Operator<T, T> {
  *
  * #### Arguments:
  *
- * @param {Stream} other Some other stream that is used to know when should the
- * output stream of this operator start emitting.
+ * @param {Stream} other Some other stream that is used to know when the output
+ * stream of this operator should start emitting.
  * @return {Stream}
  */
 export default function dropUntil<T>(other: Stream<any>): (ins: Stream<T>) => Stream<T> {

--- a/tests/extra/dropUntil.ts
+++ b/tests/extra/dropUntil.ts
@@ -1,6 +1,7 @@
 /// <reference types="mocha"/>
 /// <reference types="node" />
 import xs from '../../src/index';
+import concat from '../../src/extra/concat';
 import dropUntil from '../../src/extra/dropUntil';
 import delay from '../../src/extra/delay';
 import * as assert from 'assert';
@@ -20,15 +21,47 @@ describe('dropUntil (extra)', () => {
       complete: () => {
         assert.strictEqual(expected.length, 0);
         done();
-      },
+      }
     });
   });
 
-  it('should complete the stream when another stream emits complete', (done: any) => {
-    const source = xs.periodic(50).take(6);
-    const other = xs.empty().compose(delay(220));
+  it('should emit no items if another stream is empty', (done: any) => {
+    const source = xs.periodic(10).take(10);
+    const other = xs.empty().compose(delay(50));
     const stream = source.compose(dropUntil(other));
-    const expected = [4, 5];
+    let emissions = 0;
+    stream.addListener({
+      next: () => emissions++,
+      error: (err: any) => done(err),
+      complete: () => {
+        assert.strictEqual(emissions, 0);
+        done();
+      }
+    });
+  });
+
+  it('should not wait for another stream to complete', (done: any) => {
+    const source = xs.periodic(50).take(2);
+    const other = concat(xs.of('foo'), xs.never());
+    const stream = source.compose(dropUntil(other));
+    const expected = [0, 1];
+    stream.addListener({
+      next: (x: number) => {
+        assert.strictEqual(x, expected.shift());
+      },
+      error: (err: any) => done(err),
+      complete: () => {
+        assert.strictEqual(expected.length, 0);
+        done();
+      }
+    });
+  });
+
+  it('should not complete the stream when another non empty stream emits complete', (done: any) => {
+    const source = xs.periodic(50).take(8);
+    const other = xs.periodic(1).take(1).compose(delay(220));
+    const stream = source.compose(dropUntil(other));
+    const expected = [4, 5, 6, 7];
 
     stream.addListener({
       next: (x: number) => {
@@ -38,7 +71,7 @@ describe('dropUntil (extra)', () => {
       complete: () => {
         assert.strictEqual(expected.length, 0);
         done();
-      },
+      }
     });
   });
 });


### PR DESCRIPTION
Refactor `dropUntil` to leave its output stream unchanged when its 'other' stream completes. Make output stream empty if 'other' stream is empty.

This change aligns `dropUntil` more closely with the [`skipUntil` operator from rxjs.](https://github.com/ReactiveX/rxjs/blob/37d9ea9a8665d0c4b6593da4c237e037e98f66b5/spec/operators/skipUntil-spec.ts)

## Description

The other internal listener in `dropUntil` now treats completion as a `noop`. Additionally, when source completes, we no longer call `up()`, which seems like a pretty major bug to begin with.

Instead, completion of the source now calls `_stop()`, which removes the internal listener to source and detaches the output stream from the operator. **This is definitely a situation where we need ComVer, since consumers may have unknowingly relied on this behavior, which never removed the internal listener to the source stream.**

Resolves #237.

## Motivation and Context

`dropUntil` is designed to keep a result stream _silent_ until some other stream emits. However, the implementation of `dropUntil` left ambiguous how the operator should behave when either the source stream, or the other (notifier) stream, completes.

The documentation for `dropUntil` gave consumers the impression that the result stream would complete if the 'other' stream completed. However, we had no tests that verified this behavior was correct. Confusion about how the operator should behave led to opening #237.

Aligning the operator's behavior with another implementation (from rxjs) is _okay_, but I consider this change to really be an improvement to the operator. Treating completion as a `noop` is essential because there is no semantic meaning associated with the other stream completing, _for this operator_. If a consumer needed semantics for declaring when their stream should end, they can reach for `endWhen`, or another extra.

Additionally, if the consumer wanted the semantics of `dropUntil` and _didn't_ want `endWhen` behavior, this extra wasn't helpful. They'd have to roll their own.

## How Has This Been Tested?

I've changed one existing test, and added two more. The altered test has had its expectation reversed:
> should _**not**_ complete the stream when another _**non empty**_ stream emits complete

The new tests are largely borrowed from the `rxjs` expectations of `skipUntil`. They can be summarized as:

> If source is infinite, the result stream is infinite.
> If source completes, the result stream completes.

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.