### PR TITLE
feat(debounce): emit pending value on completion

### DIFF
--- a/src/extra/debounce.ts
+++ b/src/extra/debounce.ts
@@ -1,10 +1,10 @@
-import {Operator, Stream} from '../index';
+import {Operator, Stream, NO} from '../index';
 
 class DebounceOperator<T> implements Operator<T, T> {
   public type = 'debounce';
   public out: Stream<T> = null as any;
   private id: any = null;
-  private t: any = null;
+  private t: any = NO;
 
   constructor(public dt: number,
               public ins: Stream<T>) {
@@ -37,7 +37,7 @@ class DebounceOperator<T> implements Operator<T, T> {
     this.id = setInterval(() => {
       this.clearInterval();
       u._n(t);
-      this.t = null;
+      this.t = NO;
     }, this.dt);
   }
 
@@ -52,8 +52,8 @@ class DebounceOperator<T> implements Operator<T, T> {
     const u = this.out;
     if (!u) return;
     this.clearInterval();
-    if (this.t != null) u._n(this.t);
-    this.t = null;
+    if (this.t != NO) u._n(this.t);
+    this.t = NO;
     u._c();
   }
 }

--- a/src/extra/debounce.ts
+++ b/src/extra/debounce.ts
@@ -52,7 +52,8 @@ class DebounceOperator<T> implements Operator<T, T> {
     const u = this.out;
     if (!u) return;
     this.clearInterval();
-    if (this.t) u._n(this.t);
+    if (this.t != null) u._n(this.t);
+    this.t = null;
     u._c();
   }
 }

--- a/src/extra/debounce.ts
+++ b/src/extra/debounce.ts
@@ -4,6 +4,7 @@ class DebounceOperator<T> implements Operator<T, T> {
   public type = 'debounce';
   public out: Stream<T> = null as any;
   private id: any = null;
+  private t: any = null;
 
   constructor(public dt: number,
               public ins: Stream<T>) {
@@ -32,9 +33,11 @@ class DebounceOperator<T> implements Operator<T, T> {
     const u = this.out;
     if (!u) return;
     this.clearInterval();
+    this.t = t;
     this.id = setInterval(() => {
       this.clearInterval();
       u._n(t);
+      this.t = null;
     }, this.dt);
   }
 
@@ -49,6 +52,7 @@ class DebounceOperator<T> implements Operator<T, T> {
     const u = this.out;
     if (!u) return;
     this.clearInterval();
+    if (this.t) u._n(this.t);
     u._c();
   }
 }

--- a/tests/extra/debounce.ts
+++ b/tests/extra/debounce.ts
@@ -2,6 +2,7 @@
 /// <reference types="node" />
 import xs, {Listener, Producer} from '../../src/index';
 import debounce from '../../src/extra/debounce';
+import fromDiagram from '../../src/extra/fromDiagram';
 import * as assert from 'assert';
 
 describe('debounce (extra)', () => {
@@ -28,5 +29,35 @@ describe('debounce (extra)', () => {
       complete: () => done(new Error('This should not be called')),
     };
     stream.addListener(listener);
+  });
+
+  it('should emit any pending value upon completion', (done: any) => {
+    const stream = fromDiagram('-1----2-|').compose(debounce(50));
+    const expected = [1, 2];
+    stream.addListener({
+      next: (x: number) => {
+        assert.equal(x, expected.shift());
+      },
+      error: (err: Error) => done(err),
+      complete: () => {
+        assert.strictEqual(expected.length, 0);
+        done();
+      },
+    });
+  });
+
+  it('should not emit value upon completion if no pending value', (done: any) => {
+    const stream = fromDiagram('-1----2-------|').compose(debounce(50));
+    const expected = [1, 2];
+    stream.addListener({
+      next: (x: number) => {
+        assert.equal(x, expected.shift());
+      },
+      error: (err: Error) => done(err),
+      complete: () => {
+        assert.strictEqual(expected.length, 0);
+        done();
+      },
+    });
   });
 });


### PR DESCRIPTION
Emit any pending value, then complete, if a source stream completes before a debounce interval closes.

## Description
In order to be able to emit the latest value upon completion, the operator needs access to the most recent value. In the previous implementation, the emission took place in a closure created by `setTimeout`, so now the operator has a new property `t` which keeps track of this emission.

This value is cleared when the debounce interval closes and upon completion.

Resolve #257.
Probably should close #127.