### PR TITLE
Fix flatten typings for TS 3.4

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1765,7 +1765,7 @@ export class Stream<T> implements InternalListener<T> {
    *
    * @return {Stream}
    */
-  flatten<R>(this: Stream<Stream<R>>): Stream<R> {
+  flatten<R>(this: Stream<Stream<R> | MemoryStream<R>>): Stream<R> {
     return new Stream<R>(new Flatten(this));
   }
 


### PR DESCRIPTION
In later TS versions, it types flatten stream as `Stream<{}>`

```ts
  const mm$ = xs.createWithMemory<MemoryStream<number>>()
  const sm$ = xs.create<MemoryStream<number>>()
  const ms$ = xs.createWithMemory<Stream<number>>()
  const ss$ = xs.create<Stream<number>>()
  const fmm$ = mm$.flatten() // without fix this is typed to Stream<{}> not Stream<number>
  const fsm$ = sm$.flatten()
  const fms$ = ms$.flatten()
  const fss$ = ss$.flatten()
```