### PR TITLE
Fixes issue #279

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
   <link rel="stylesheet" href="//cdn.jsdelivr.net/font-hack/2.019/css/hack.min.css">
-  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="css/main.css">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
 </head>


### PR DESCRIPTION
Fixes #279 

I haven't really tested it by building the site because I don't know how to do that but replacing `/css/main.css` to `css/main.css` using dev-tools worked.

Maybe this bookmarklet would help to test: `javascript:document.querySelector('link[href="/css/main.css"]').setAttribute("href", "css/main.css")`
