### PR TITLE
Make empty() and never() have Stream<never> type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1284,8 +1284,8 @@ export class Stream<T> implements InternalListener<T> {
    * @factory true
    * @return {Stream}
    */
-  static never(): Stream<any> {
-    return new Stream<any>({ _start: noop, _stop: noop });
+  static never(): Stream<never> {
+    return new Stream<never>({ _start: noop, _stop: noop });
   }
 
   /**
@@ -1302,8 +1302,8 @@ export class Stream<T> implements InternalListener<T> {
    * @factory true
    * @return {Stream}
    */
-  static empty(): Stream<any> {
-    return new Stream<any>({
+  static empty(): Stream<never> {
+    return new Stream<never>({
       _start(il: InternalListener<any>) { il._c(); },
       _stop: noop,
     });


### PR DESCRIPTION
Updated typings so that `empty()` and `never()` have `Stream<never>` type, instead of `Stream<any>` type.

This pull request addresses https://github.com/staltz/xstream/issues/281.
Since there are no other opinions over a half year, I've sent a PR as an advanced step of the proposal.

@staltz If you are against for the changes, please feel free to close this 🙏 