### PR TITLE
Use `never` for never stream instead of `any`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1284,8 +1284,8 @@ export class Stream<T> implements InternalListener<T> {
    * @factory true
    * @return {Stream}
    */
-  static never(): Stream<any> {
-    return new Stream<any>({ _start: noop, _stop: noop });
+  static never(): Stream<never> {
+    return new Stream<never>({ _start: noop, _stop: noop });
   }
 
   /**


### PR DESCRIPTION
Using `never` type should allow us to have the _next_ value of `never` stream with `never` type.