### PR TITLE
debounce: clear emit timer interval on stop

### DIFF
--- a/src/extra/debounce.ts
+++ b/src/extra/debounce.ts
@@ -18,7 +18,7 @@ class DebounceOperator<T> implements Operator<T, T> {
   _stop(): void {
     this.ins._remove(this);
     this.out = null as any;
-    this.id = null;
+    this.clearInterval();
   }
 
   clearInterval() {


### PR DESCRIPTION
There is a possible bug when timer is set (not yet executed) and stream stopped. If timer interval is not cleared it results in infinite emitting (not sure why emitting is looped).

 I don't have a clean simple repro example, but it happened in my app, had to debug it. 

Anyway it seems logical to clear not executed emit interval on `stop`, and not to clear it is a potential problem.