### PR TITLE
feat: add never and empty <T = any> param

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1281,7 +1281,7 @@ export class Stream<T> implements InternalListener<T> {
    * @factory true
    * @return {Stream}
    */
-  static never<T = any>(): Stream<any> {
+  static never<T = any>(): Stream<T> {
     return new Stream<T>({ _start: noop, _stop: noop });
   }
 
@@ -1299,7 +1299,7 @@ export class Stream<T> implements InternalListener<T> {
    * @factory true
    * @return {Stream}
    */
-  static empty<T = any>(): Stream<any> {
+  static empty<T = any>(): Stream<T> {
     return new Stream<T>({
       _start(il: InternalListener<any>) { il._c(); },
       _stop: noop,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1281,8 +1281,8 @@ export class Stream<T> implements InternalListener<T> {
    * @factory true
    * @return {Stream}
    */
-  static never(): Stream<any> {
-    return new Stream<any>({ _start: noop, _stop: noop });
+  static never<T = any>(): Stream<any> {
+    return new Stream<T>({ _start: noop, _stop: noop });
   }
 
   /**
@@ -1299,8 +1299,8 @@ export class Stream<T> implements InternalListener<T> {
    * @factory true
    * @return {Stream}
    */
-  static empty(): Stream<any> {
-    return new Stream<any>({
+  static empty<T = any>(): Stream<any> {
+    return new Stream<T>({
       _start(il: InternalListener<any>) { il._c(); },
       _stop: noop,
     });


### PR DESCRIPTION
This would allow such things without typing issues:
```ts
declare const $some: Stream<number> | undefined

($some || xs.empty<number>()).map(x => -x)
```