### PR TITLE
chore(deps): Upgrade symbol-observable to version 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
   },
   "homepage": "https://github.com/staltz/xstream#readme",
   "dependencies": {
-    "symbol-observable": "1.2.0"
+    "@types/globalthis": "^1.0.1",
+    "globalthis": "^1.0.1",
+    "symbol-observable": "^2.0.3"
   },
   "devDependencies": {
     "@types/mocha": "^2.2.40",
@@ -64,13 +66,13 @@
     "markdox": "0.1.10",
     "mkdirp": "0.5.1",
     "mocha": "^5.2.0",
-    "most": "1.0.3",
+    "most": "^1.9.0",
     "sinon": "1.16.0",
     "strip-comments": "0.4.4",
     "ts-node": "6.0.x",
     "tsify": "4.0.x",
     "tslint": "5.7.0",
-    "typescript": "3.2.x",
+    "typescript": "^3.4.0",
     "validate-commit-msg": "2.4.x"
   },
   "publishConfig": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,7 @@
-import $$observable from 'symbol-observable';
+import ponyfillSymbolObservable from 'symbol-observable/ponyfill';
+import { getPolyfill as getGlobalThis } from 'globalthis';
+
+const $$observable = ponyfillSymbolObservable(getGlobalThis());
 
 const NO = {};
 function noop() { }
@@ -1415,7 +1418,7 @@ export class Stream<T> implements InternalListener<T> {
    * @return {Stream}
    */
   static fromObservable<T>(obs: { subscribe: any }): Stream<T> {
-    if ((obs as Stream<T>).endWhen) return obs as Stream<T>;
+    if ((obs as Stream<T>).endWhen !== undefined) return obs as Stream<T>;
     const o = typeof obs[$$observable] === 'function' ? obs[$$observable]() : obs;
     return new Stream<T>(new FromObservable(o));
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,15 +2,21 @@
 # yarn lockfile v1
 
 
-"@most/multicast@^1.2.3":
+"@most/multicast@^1.2.5":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@most/multicast/-/multicast-1.3.0.tgz#e01574840df634478ac3fabd164c6e830fb3b966"
+  integrity sha512-DWH8AShgp5bXn+auGzf5tzPxvpmEvQJd0CNsApOci1LDF4eAEcnw4HQOr2Jaa+L92NbDYFKBSXxll+i7r1ikvw==
   dependencies:
     "@most/prelude" "^1.4.0"
 
 "@most/prelude@^1.4.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.7.0.tgz#0956ed464ad03e7fc95143eac0c6dd028498d975"
+
+"@types/globalthis@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@types/globalthis/-/globalthis-1.0.1.tgz#5310a812c2ef3905b821a1b219ae0e0d12d0e5f1"
+  integrity sha512-gPIOjEAp9ZysUzOYlwuaedjwxRW9QvMhlN5PSWCXYEw894QB/84YgXSsei8yE6D/FstC1QIrHgO7UfQ2A37M0Q==
 
 "@types/mocha@^2.2.40":
   version "2.2.44"
@@ -1378,6 +1384,13 @@ deep-is@~0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
 
+define-properties@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
+  integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+  dependencies:
+    object-keys "^1.0.12"
+
 define-property@^0.2.5:
   version "0.2.5"
   resolved "https://registry.yarnpkg.com/define-property/-/define-property-0.2.5.tgz#c35b1ef918ec3c990f9a5bc57be04aacec5c8116"
@@ -1797,6 +1810,13 @@ global-prefix@^0.1.4:
 globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
+
+globalthis@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/globalthis/-/globalthis-1.0.1.tgz#40116f5d9c071f9e8fb0037654df1ab3a83b7ef9"
+  integrity sha512-mJPRTc/P39NH/iNG4mXa9aIhNymaQikTrnspeCa2ZuJ+mH2QN/rXwtX3XwKrHqWgUQFbNZKtHM105aHzJalElw==
+  dependencies:
+    define-properties "^1.1.3"
 
 google-closure-compiler-js@^20170910.0.0:
   version "20170910.0.1"
@@ -2495,13 +2515,15 @@ module-deps@^4.0.2:
     through2 "^2.0.0"
     xtend "^4.0.0"
 
-most@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/most/-/most-1.0.3.tgz#eda0adff275c471f8fc920f871e64df864c57a6a"
+most@^1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/most/-/most-1.9.0.tgz#a689b1191a67c25776068b00cf3446e429752743"
+  integrity sha512-M7yHMcMGaclzEL6eg8Yh8PlAsaWfL/oSThF4+ZuWKM5CKXcbzmLh+qESwgZFzMKHJ+iVJwb28yFvDEOobI653w==
   dependencies:
-    "@most/multicast" "^1.2.3"
+    "@most/multicast" "^1.2.5"
     "@most/prelude" "^1.4.0"
-    symbol-observable "^1.0.2"
+    globalthis "^1.0.1"
+    symbol-observable "^2.0.3"
 
 ms@2.0.0:
   version "2.0.0"
@@ -2544,6 +2566,11 @@ number-is-nan@^1.0.0:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-keys@^1.0.12:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -3195,13 +3222,10 @@ supports-color@^5.3.0:
   dependencies:
     has-flag "^3.0.0"
 
-symbol-observable@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
-
-symbol-observable@^1.0.2:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.1.0.tgz#5c68fd8d54115d9dfb72a84720549222e8db9b32"
+symbol-observable@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
+  integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
 
 syntax-error@^1.1.1:
   version "1.3.0"
@@ -3337,10 +3361,10 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@3.2.x:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.2.2.tgz#fe8101c46aa123f8353523ebdcf5730c2ae493e5"
-  integrity sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==
+typescript@^3.4.0:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 uc.micro@^1.0.1:
   version "1.0.3"


### PR DESCRIPTION
This upgrade brings xstream into the set of npm packages that can be safely run without any mutation of primordial prototypes. Such packages can be used in applications that freeze the prototypes to mitigate prototype pollution supply chain attacks.  For example, `xstream` is in the supply chain for the CosmJS financial instruments project and would benefit from such safety measures.

This is considered a breaking change on account of the unlikely possibility that a platform exists that does not support both Symbol and Symbol.for. This hypothetical platform would no longer be supported.

Closes #312