### PR TITLE
Make strict mode Stream<T> covariant on T

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "doctest": "markdown-doctest",
     "setup-browser-tests": "browserify browser-tests/index.ts -p [ tsify ] > browser-tests/tests-bundle.js",
     "teardown-browser-tests": "rm browser-tests/tests-bundle.js",
-    "compile": "tsc -P ./tsconfig.strict.json",
+    "compile": "tsc -P ./tsconfig.build.json",
     "page-content": "npm run compile && rm -rf .ignore/ && mkdirp .ignore/ && npm run changelog && node tools/make-toc.js && node tools/make-factories.js && node tools/make-methods.js && cat markdown/header.md markdown/generated-toc.md markdown/overview.md markdown/generated-factories.md markdown/generated-methods.md markdown/footer.md > .ignore/content.md",
     "extra-docs": "node tools/make-extras.js && rm EXTRA_DOCS.md && cp markdown/generated-extras.md EXTRA_DOCS.md",
     "readme": "npm run page-content && cat markdown/readme-title.md .ignore/content.md > README.md",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,12 @@ export interface InternalListener<T> {
   _c: () => void;
 }
 
+export interface InternalListenerExt<T> {
+  _n: <V extends T>(v: V) => void;
+  _e: (err: any) => void;
+  _c: () => void;
+}
+
 const NO_IL: InternalListener<any> = {
   _n: noop,
   _e: noop,
@@ -1069,9 +1075,9 @@ class Take<T> implements Operator<T, T> {
 
 export class Stream<T> implements InternalListener<T> {
   public _prod: InternalProducer<T>;
-  protected _ils: Array<InternalListener<T>>; // 'ils' = Internal listeners
+  protected _ils: Array<InternalListenerExt<T>>; // 'ils' = Internal listeners
   protected _stopID: any;
-  protected _dl: InternalListener<T>; // the debug listener
+  protected _dl: InternalListenerExt<T>; // the debug listener
   protected _d: boolean; // flag indicating the existence of the debug listener
   protected _target: Stream<T> | null; // imitation target if this Stream will imitate
   protected _err: any;

--- a/tests/extra/dropRepeats.ts
+++ b/tests/extra/dropRepeats.ts
@@ -56,7 +56,7 @@ describe('dropRepeats (extra)', () => {
   });
 
   it('should drop consecutive duplicate numbers, with a circular stream dependency', (done: any) => {
-    const streamProxy = xs.create();
+    const streamProxy = xs.create<number>();
     const input = xs.of(0, 0, 1, 1, 1);
     const stream = xs.merge(streamProxy, input).compose(dropRepeats());
     streamProxy.imitate(stream);

--- a/tests/extra/fromEvent.ts
+++ b/tests/extra/fromEvent.ts
@@ -7,10 +7,10 @@ function noop() {}
 
 class FakeEventTarget implements EventTarget {
   public handler: EventListener | undefined;
-  public event: string;
-  public capture: boolean;
-  public removedEvent: string;
-  public removedCapture: boolean;
+  public event: string | undefined;
+  public capture: boolean | undefined;
+  public removedEvent: string | undefined;
+  public removedCapture: boolean | undefined;
 
   constructor() {}
 
@@ -41,8 +41,8 @@ class FakeEventTarget implements EventTarget {
 
 class FakeEventEmitter extends EventEmitter {
   public handler: Function | undefined;
-  public event: string | symbol;
-  public removedEvent: string | symbol;
+  public event: string | symbol | undefined;
+  public removedEvent: string | symbol | undefined;
 
   constructor() {
     super();

--- a/tests/factory/fromObservable.ts
+++ b/tests/factory/fromObservable.ts
@@ -25,7 +25,7 @@ describe('xs.fromObservable', () => {
   });
 
   it('should support synchronous unsubscribe on completion', (done: any) => {
-    const stream = xs.fromObservable(xs.of(10, 20, 30));
+    const stream = xs.fromObservable<number>(xs.of(10, 20, 30));
     let expected = [10, 20, 30];
 
     stream.addListener({

--- a/tests/operator/filter.ts
+++ b/tests/operator/filter.ts
@@ -127,10 +127,10 @@ describe('Stream.prototype.filter', () => {
   it('should return stream of constrained type if predicate is type guard', (done: any) => {
     class Animal { }
     class Dog extends Animal {
-      thisIsADog: boolean;
+      thisIsADog: boolean | undefined;
     }
     class Cat extends Animal {
-      thisIsACat: boolean;
+      thisIsACat: boolean | undefined;
     }
 
     function isDog(a: Animal): a is Dog {

--- a/tests/operator/replaceError.ts
+++ b/tests/operator/replaceError.ts
@@ -35,7 +35,7 @@ describe('Stream.prototype.replaceError', () => {
       {type: 'complete'},
     ];
 
-    const source = xs.create({
+    const source = xs.create<number>({
       start: (listener) => {
         while (events.length > 0) {
           const event = events.shift();
@@ -83,7 +83,7 @@ describe('Stream.prototype.replaceError', () => {
     ];
     const source = xs.create(<Producer<number>> {
       on: false,
-      start: (listener) => {
+      start: function (this: {on: boolean}, listener) {
         this.on = true;
         for (let i = 0; i < events.length; i++) {
           if (!this.on) return;
@@ -96,7 +96,7 @@ describe('Stream.prototype.replaceError', () => {
           }
         }
       },
-      stop: () => {
+      stop: function (this: {on: boolean}) {
         this.on = false;
       },
     });

--- a/tests/operator/take.ts
+++ b/tests/operator/take.ts
@@ -82,22 +82,22 @@ describe('Stream.prototype.take', () => {
 
   it('should terminate properly when "next" function recursively calls itself', (done: any) => {
     const producer = {
-      start: (listener: any) => {
+      start: function (this: any, listener: any) {
         this.listener = listener;
         listener.next(1);
       },
-      _n: (value: any) => {
+      _n: function  (this: any, value: any) {
         const listener = this.listener;
         if (listener) listener.next(value);
       },
-      _e: (value: string) => {
+      _e: function (this: any, value: string){
         const listener = this.listener;
         if (listener) listener.error(value);
       },
-      stop: () => this.listener = null,
+      stop: function (this: any) { this.listener = null; },
       listener: null
     };
-    const stream = xs.create(producer);
+    const stream = xs.create<number>(producer);
 
     let nextCount = 0;
     stream.take(1).addListener({

--- a/tests/stream.ts
+++ b/tests/stream.ts
@@ -78,7 +78,7 @@ describe('Stream', () => {
     const expected = [10, 20, 30];
     let listenerGotEnd: boolean = false;
 
-    const stream = xs.create();
+    const stream = xs.create<number>();
 
     stream.addListener({
       next: (x: number) => {
@@ -201,7 +201,7 @@ describe('Stream', () => {
 
   it('should synchronously stop producer when completed', (done: any) => {
     let on = false;
-    const stream = xs.create({
+    const stream = xs.create<number>({
       start: (listener) => {
         on = true;
         listener.next(10);
@@ -248,7 +248,7 @@ describe('Stream', () => {
 
   it('should synchronously stop producer when error thrown', (done: any) => {
     let on = false;
-    const stream = xs.create({
+    const stream = xs.create<number>({
       start: (listener) => {
         on = true;
         listener.next(10);

--- a/tests/types.ts
+++ b/tests/types.ts
@@ -2,3 +2,7 @@ import xs from '../src/index';
 
 // can be used as type
 type T = xs<any>;
+
+// check Stream<T> covariant on T
+const n$ = xs.create<number>();
+const ns$: xs<number | string> = n$;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -6,10 +6,9 @@
         "inlineSourceMap": true,
         "inlineSources": true,
         "declaration": true,
-        "noImplicitAny": true,
         "noUnusedLocals": true,
-        "noUnusedParameters": true,
-        "strict": true,
+        "noUnusedParameters": true,        
+        "outDir": "./",
     },
     "files": [
         "src/extra/buffer.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,10 @@
 {
   "compilerOptions": {
-    "moduleResolution": "node",
     "suppressImplicitAnyIndexErrors": true,
+    "strict": true,
     "module": "commonjs",
     "noEmitHelpers": false,
-    "target": "ES5",
-    "outDir": "./",
+    "target": "ES5",    
     "lib": ["dom", "es5", "es2015.collection", "es2015.promise"]
   },
   "formatCodeOptions": {


### PR DESCRIPTION
This PR:
- enforces TS `strict` mode on the whole repo
- makes `Stream<T>` covariant on `T` by modifying inner `_ils`, `_dl` types.
