### PR TITLE
fix: add skipLibCheck to fix build issue

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,8 @@
     "module": "commonjs",
     "noEmitHelpers": false,
     "target": "ES5",
-    "outDir": "./"
+    "outDir": "./",
+    "skipLibCheck": true,
   },
   "formatCodeOptions": {
     "indentSize": 2,


### PR DESCRIPTION
@staltz this PR is to be released as either v6.6.1 or v6.7. It adds `skipLibCheck: true` to the tsconfig.