### PR TITLE
Fix throttle not clearing its internal interval when unsubscribed

### DIFF
--- a/src/extra/throttle.ts
+++ b/src/extra/throttle.ts
@@ -17,7 +17,7 @@ class ThrottleOperator<T> implements Operator<T, T> {
   _stop(): void {
     this.ins._remove(this);
     this.out = null as any;
-    this.id = null;
+    this.clearInterval();
   }
 
   clearInterval() {


### PR DESCRIPTION
When a throttled stream is unsubscribed, its internal throttle interval is not cleared, and the reference to its ID is removed, meaning it's also not cleared at the end of the timeout.

This is essentially a memory leak, where the interval will live on in the event loop forever without being cleared.

This PR adds a call to `ThrottleOperator#clearInterval()` in its `_stop` method, clearing the interval and freeing it from the event loop.

----

I checked if the same problem exists for `debounce`, but it looks like it was already fixed in https://github.com/staltz/xstream/pull/296:

https://github.com/staltz/xstream/blob/fee5f0d1ea23becc5aa89064624b609a105104b3/src/extra/debounce.ts#L18-L22